### PR TITLE
Faster zipping experiment

### DIFF
--- a/tasks/mapreads.wdl
+++ b/tasks/mapreads.wdl
@@ -33,7 +33,7 @@ task map_reads {
 		Int preempt = 2
 	}
 	String outfile = "~{sample_name}.sam" # hardcoded for now
-	String basestem_reference = sub(basename(DIRZIPPD_reference), "\.zip(?!.{5,})", "")  # TODO: double check the regex
+	String basestem_reference = sub(basename(DIRZIPPD_reference), "\.tar.gz(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{FILENAME_reference}"
 
@@ -64,7 +64,8 @@ task map_reads {
 	if [[ ! "~{DIRZIPPD_reference}" = "" ]]
 	then
 		cp ~{DIRZIPPD_reference} .
-		unzip ~{basestem_reference}.zip
+		gunzip ~{basestem_reference}.tar.gz # could also use pigs for this, not sure if it'd actually be faster
+		tar -xvf ~{basestem_reference}.tar
 	fi
 
 	clockwork map_reads ~{arg_unsorted_sam} ~{sample_name} ~{arg_ref_fasta} ~{outfile} ~{sep=" " reads_files}

--- a/tasks/refprep.wdl
+++ b/tasks/refprep.wdl
@@ -67,6 +67,8 @@ task reference_prepare {
 	command <<<
 		set -eux -o pipefail
 
+		apt-get install pigz -y  # zip has forced my hand
+
 		if [[ ! "~{FILE_DIRZIPPD_reference_TASKIN}" = "" ]]
 		then
 			cp ~{FILE_DIRZIPPD_reference_TASKIN} .
@@ -75,9 +77,7 @@ task reference_prepare {
 
 		clockwork reference_prepare --outdir ~{outdir} ~{arg_ref} ~{arg_cortex_mem_height} ~{arg_tsv} ~{arg_name}
 
-		rm ~{basename_reference} # needed to prevent output glob grabbing the wrong file
-
-		zip -r ~{outdir}.zip ~{outdir}
+		tar cf - ~{outdir}/ | pigz --fast > ~{outdir}.tar.gz
 
 		ls -lhaR > workdir.txt
 	>>>
@@ -91,8 +91,8 @@ task reference_prepare {
 		preemptible: "${preempt}"
 	}
 	output {
-		File    file_dirzipped_refprepd_taskout = glob("*.zip")[0]
-		String  STRG_FILENAME_refprepd_taskout = select_first([FILE_LONESOME_reference_TASKIN, STRG_FILENAME_reference_TASKIN, "error"])
+		File    file_dirzipped_refprepd_taskout = glob("*.tar.gz")[0]
+		String  STRG_FILENAME_refprepd_taskout = "ref.fa" # seems to always be this
 		# it is assumed that if indexing the decontam ref, the file remove_contam_metadata.tsv will be created in file_dirzipped_refprepd_taskout
 		File    debug_workdir = "workdir.txt"
 	}

--- a/tasks/remove-contam.wdl
+++ b/tasks/remove-contam.wdl
@@ -56,7 +56,8 @@ task remove_contam {
 	if [[ ! "~{DIRZIPPD_decontam_ref}" = "" ]]
 	then
 		cp ~{DIRZIPPD_decontam_ref} .
-		unzip ~{basestem_reference}.zip
+		gunzip ~{basestem_reference}.tar.gz # could also use pigs for this, not sure if it'd actually be faster
+		tar -xvf ~{basestem_reference}.tar
 	fi
 
 	clockwork remove_contam \

--- a/tasks/remove-contam.wdl
+++ b/tasks/remove-contam.wdl
@@ -37,7 +37,7 @@ task remove_contam {
 	String arg_reads_out2 = if(defined(reads_out_2)) then "~{reads_out_2}" else "~{intermed_basestem_bamin}.decontam_2.fq.gz"
 
 	# the metadata TSV will be either be passed in directly, or will be zipped in DIRZIPPD_decontam_ref
-	String basestem_reference = sub(basename(select_first([DIRZIPPD_decontam_ref, "bogus fallback value"])), "\.zip(?!.{5,})", "") # TODO: double check the regex
+	String basestem_reference = sub(basename(select_first([DIRZIPPD_decontam_ref, "bogus fallback value"])), "\.tar.gz(?!.{5,})", "") # TODO: double check the regex
 	String arg_metadata_tsv = if(defined(DIRZIPPD_decontam_ref)) then "~{basestem_reference}/~{FILENAME_metadata_tsv}" else "~{metadata_tsv}"
 	
 	# calculate the optional inputs

--- a/walkthru.wdl
+++ b/walkthru.wdl
@@ -20,10 +20,10 @@ version 1.0
 #import "../enaBrowserTools-wdl/tasks/enaDataGet.wdl" as enaDataGetTask
 #import "./tasks/remove-contam.wdl" as clockwork_removecontamTask
 
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/rename-variables/wf-refprep-TB.wdl" as clockwork_refprepWF
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/rename-variables/tasks/mapreads.wdl" as clockwork_mapreadsTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/faster-zipping-experiment/wf-refprep-TB.wdl" as clockwork_refprepWF
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/faster-zipping-experiment/tasks/mapreads.wdl" as clockwork_mapreadsTask
 import "https://raw.githubusercontent.com/aofarrel/enaBrowserTools-wdl/0.0.3/tasks/enaDataGet.wdl" as enaDataGetTask
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/rename-variables/tasks/remove-contam.wdl" as clockwork_removecontamTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/faster-zipping-experiment/tasks/remove-contam.wdl" as clockwork_removecontamTask
 
 workflow ClockworkWalkthrough {
 	input {

--- a/wf-refprep-TB.wdl
+++ b/wf-refprep-TB.wdl
@@ -2,8 +2,8 @@ version 1.0
 #import "./tasks/refprep.wdl"
 #import "./tasks/dl-TB-ref.wdl" as dl_TB_ref
 
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/rename-variables/tasks/refprep.wdl"
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/rename-variables/tasks/dl-TB-ref.wdl" as dl_TB_ref
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/faster-zipping-experiment/tasks/refprep.wdl"
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/faster-zipping-experiment/tasks/dl-TB-ref.wdl" as dl_TB_ref
 
 # correspond with https://github.com/iqbal-lab-org/clockwork/wiki/Walkthrough-scripts-only#get-and-index-reference-genomes
 


### PR DESCRIPTION
I can't believe I'm only just after learning about [pigz](https://zlib.net/pigz/)...

This saves about 40 minutes per shard. It just works. Perfectly. I'm astounded. Why is this not the default?

In the future it might be worth adding the pigz installation to every task and/or remaking the Docker image so it includes pigz already.