### PR TITLE
Tar outputs instead of zipping them, remove some variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,38 +25,10 @@ All are Cromwell-formatted.
 ## Note to local Cromwell users
  My testing indicates that running the refprep workflow on a typical laptop setup will not be successful due to processes getting sigkilled thanks to lack of compute resources. You'll know you're having this issue because you will see "killed" and/or a return code of 137 in your Clockwork logs (you likely won't see this in Cromwell's terminal output). You may have some luck increasing Docker's resources or running more than once, but it's probably best to run these once in the cloud, download the results, and then use them as bluepeter inputs from then on (or just run the whole thing in the cloud).
 
-## Variable weirdness
-The original pipeline assumes that you can pass entire directories around. WDL 1.0 does allow for this, and Cromwell has (to my knowledge) no timeline on supporting WDL 1.1, so we have to get a little creative. When dealing with an input variable that is often passed in from a directory, the following naming schema is used (inconsistently, because everything is still in development):
-
-Public:    
-* STRG_FILENAME_varname: String - "cromwell_inputs/remove_contam_metadata.tsv"  
-* STRG_DIRNOZIP_varname: String - "cromwell_inputs/Ref.remove_contam"  
-* FILE_DIRZIPPD_varname: File   - "cromwell_inputs/Ref.remove_contam.zip"  
-* FILE_LONESOME_varname: File   - "cromwell_inputs/remove_contam_metadata.tsv"
-
-Private:  
-* strg_fullpath_varname: String - "cromwell_inputs/Ref.remove_contam/remove_contam_metadata.tsv"
-* strg_basestem_varname: String - "Ref.remove_contam"
-* strg_intermed_varname: String - Intermediate variable used to calculate arg_varname. Not always present.  
-* strg_argument_varname: String - Argument for a command line call in a task's command section.
-
-Suffixes:
-* \_TASKIN: Variable is a task-level input
-* \_taskout: Variable is a task-level output
-* \_wrkfinn: Variable is a workflow-level input
-* \_wrkfout: Variable is a workflow-level output
-
-Generally speaking:
-
-`arg_varname = if(defined(fullpath_varname)) then "~{fullpath_varname}" else "~{dirnozip_varname}/~{filename_varname}"`
-
-...with the assumption that `~{dirzippd_varname}` gets unzipped before arg_varname is used in the command section.
-
 ## To-do list:
 [X] Investigate why Terra ran enaDataGet very quickly, no error, but cromwell failed to find any fastq.gz files  
-[] Use the newly-coined naming schema consistently and/or simplify variable nonsense  
-[] Finish the walkthru pipeline  
-[] Better cloud runtime attribute estimates  
+[X] Finish the walkthru pipeline  
+[X] Better cloud runtime attribute estimates  
 [X] Merge bluepeter version of refprep with non-bluepeter version  
 [X] Merge bluepeter version of walkthru with non-bluepeter version  
 [] Finish miscellanous TODO stuff in code  

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
  * mapreads: implementation of `clockwork map_reads`
  * refprep: limited implementation of `clockwork reference_prepare`, does not support databases
  * remove-contam: implementation of `clockwork remove_contam`
+ * variant_call_one_sample: implementation of `clockwork variant_call_one_sample`
 
  **Workflows**
  * wf-refprep-generic: runs a generic refprep workflow
  * wf-refprep-TB: runs a tuberculosis-specific refprep workflow [based on this](https://github.com/iqbal-lab-org/clockwork/wiki/Walkthrough-scripts-only#get-and-index-reference-genomes)
- * walkthru: WIP, not complete, but will eventually go from FASTQ input to minos' adjudicated VCF output
+ * walkthru: goes from FASTQ input to minos' adjudicated VCF output
 
 ## Skipping steps on walkthru.wdl
 All are Cromwell-formatted.

--- a/tasks/dl-TB-ref.wdl
+++ b/tasks/dl-TB-ref.wdl
@@ -1,5 +1,9 @@
 version 1.0
 
+# Note: It is possible a temporary outage/hiccup can cause this task to fail, so it's
+# a good idea to set retries >= 2 just in case. If this task fails unexpectedly, check
+# stderr (not the log Terra shows you by default!) and look for a wget error.
+
 task download_tb_reference_files {
 	input {
 		String outdir = "Ref.download"
@@ -7,14 +11,14 @@ task download_tb_reference_files {
 		# runtime attributes
 		Int disk = 100
 		Int cpu = 4
-		Int retries = 1
+		Int retries = 2
 		Int memory = 8
 		Int preempt = 2
 	}
 
 	command <<<
 	/clockwork/scripts/download_tb_reference_files.pl ~{outdir}
-	tar cf - ~{outdir}/
+	tar -c ~{outdir}/ > ~{outdir}.tar
 	ls -lhaR > workdir.txt
 	>>>
 

--- a/tasks/dl-TB-ref.wdl
+++ b/tasks/dl-TB-ref.wdl
@@ -11,6 +11,10 @@ task download_tb_reference_files {
 	}
 	String STRG_DIRNOZIP_outdir_TASKIN = "Ref.download" # hardcoded for now
 
+	# estimate disk size required
+	Int size_in = select_first([ceil(size(FILE_DIRZIPPD_reference_TASKIN, "GB")), ceil(size(FILE_LONESOME_reference_TASKIN, "GB")), 0])
+	Int finalDiskSize = ceil(2*size_in + addldisk)
+
 	command <<<
 	/clockwork/scripts/download_tb_reference_files.pl ~{STRG_DIRNOZIP_outdir_TASKIN}
 

--- a/tasks/dl-TB-ref.wdl
+++ b/tasks/dl-TB-ref.wdl
@@ -2,6 +2,8 @@ version 1.0
 
 task download_tb_reference_files {
 	input {
+		String outdir = "Ref.download"
+
 		# runtime attributes
 		Int disk = 100
 		Int cpu = 4
@@ -9,14 +11,11 @@ task download_tb_reference_files {
 		Int memory = 8
 		Int preempt = 2
 	}
-	String STRG_DIRNOZIP_outdir_TASKIN = "Ref.download" # hardcoded for now
 
 	command <<<
-	/clockwork/scripts/download_tb_reference_files.pl ~{STRG_DIRNOZIP_outdir_TASKIN}
-
+	/clockwork/scripts/download_tb_reference_files.pl ~{outdir}
+	tar cf - ~{outdir}/
 	ls -lhaR > workdir.txt
-
-	zip -r ~{STRG_DIRNOZIP_outdir_TASKIN}.zip ~{STRG_DIRNOZIP_outdir_TASKIN}
 	>>>
 
 	runtime {
@@ -29,7 +28,7 @@ task download_tb_reference_files {
 	}
 
 	output {
-		File   FILE_DIRZIPPD_tbref_taskout = "~{STRG_DIRNOZIP_outdir_TASKIN}.zip"
+		File   tar_tb_ref_raw = "~{outdir}.tar"
 		File   debug_workdir = "workdir.txt"
 	}
 }

--- a/tasks/dl-TB-ref.wdl
+++ b/tasks/dl-TB-ref.wdl
@@ -11,10 +11,6 @@ task download_tb_reference_files {
 	}
 	String STRG_DIRNOZIP_outdir_TASKIN = "Ref.download" # hardcoded for now
 
-	# estimate disk size required
-	Int size_in = select_first([ceil(size(FILE_DIRZIPPD_reference_TASKIN, "GB")), ceil(size(FILE_LONESOME_reference_TASKIN, "GB")), 0])
-	Int finalDiskSize = ceil(2*size_in + addldisk)
-
 	command <<<
 	/clockwork/scripts/download_tb_reference_files.pl ~{STRG_DIRNOZIP_outdir_TASKIN}
 

--- a/tasks/mapreads.wdl
+++ b/tasks/mapreads.wdl
@@ -33,7 +33,7 @@ task map_reads {
 		Int preempt = 2
 	}
 	String outfile = "~{sample_name}.sam" # hardcoded for now
-	String basestem_reference = sub(basename(DIRZIPPD_reference), "\.tar.gz(?!.{5,})", "")  # TODO: double check the regex
+	String basestem_reference = sub(basename(DIRZIPPD_reference), "\.tar(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{FILENAME_reference}"
 
@@ -52,19 +52,10 @@ task map_reads {
 	echo "outfile" ~{outfile}
 	echo "arg_unsorted_sam" ~{arg_unsorted_sam}
 	echo "arg_ref_fasta" ~{arg_ref_fasta}
-
-	# on local tests we can get away with not doing this + not passing in fastq basenames
-	# still need to ensure Terra-Cromwell localization doesn't require this 
-	#FASTQ_FILES=(~{sep=" " reads_files})
-	#for FASTQ_FILE in ${FASTQ_FILES[@]};
-	#do
-	#	cp ${FASTQ_FILE} .
-	#done
-
+	
 	if [[ ! "~{DIRZIPPD_reference}" = "" ]]
 	then
 		cp ~{DIRZIPPD_reference} .
-		gunzip ~{basestem_reference}.tar.gz # could also use pigs for this, not sure if it'd actually be faster
 		tar -xvf ~{basestem_reference}.tar
 	fi
 

--- a/tasks/refprep.json
+++ b/tasks/refprep.json
@@ -1,5 +1,5 @@
 {
   "ClockworkRefPrep.genome": "/Users/ash/Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
   "ClockworkRefPrep.reference_prepare.cortex_mem_height": 20,
-  "ClockworkRefPrep.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip"
+  "ClockworkRefPrep.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip"
 }

--- a/tasks/refprep.wdl
+++ b/tasks/refprep.wdl
@@ -70,6 +70,7 @@ task reference_prepare {
 		then
 			cp ~{reference_folder} .
 			tar -xvf ~{basestem_reference}.tar
+			rm ~{basestem_reference}.tar
 		fi
 
 		clockwork reference_prepare --outdir ~{outdir} ~{arg_ref} ~{arg_cortex_mem_height} ~{arg_tsv} ~{arg_name}

--- a/tasks/refprep.wdl
+++ b/tasks/refprep.wdl
@@ -53,7 +53,7 @@ task reference_prepare {
 	# find where the reference TSV is going to be located, if it exists at all
 	# excessive usage of select_first() is required due to basename() and sub() not working on optional types, even if setting an optional variable
 	String is_there_any_tsv = select_first([STRG_FILENAME_tsv_TASKIN, FILE_LONESOME_tsv_TASKIN, "false"])
-	String basestem_reference = sub(basename(select_first([DIRZIPPD_decontam_ref, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
+	String basestem_reference = sub(basename(select_first([reference_folder, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
 	String? intermed_tsv1 = if defined(STRG_FILENAME_tsv_TASKIN) then "~{basestem_reference}/~{STRG_FILENAME_tsv_TASKIN}" else ""
 	String? intermed_tsv2 = if defined(FILE_LONESOME_tsv_TASKIN) then "~{FILE_LONESOME_tsv_TASKIN}" else ""
 	String? arg_tsv               = if is_there_any_tsv == "false" then "" else "--contam_tsv ~{intermed_tsv1}~{intermed_tsv2}"

--- a/tasks/refprep.wdl
+++ b/tasks/refprep.wdl
@@ -88,9 +88,8 @@ task reference_prepare {
 		preemptible: "${preempt}"
 	}
 	output {
-		File    file_dirzipped_refprepd_taskout = glob("*.tar")[0]
-		String  STRG_FILENAME_refprepd_taskout = "ref.fa" # seems to always be this
-		# it is assumed that if indexing the decontam ref, the file remove_contam_metadata.tsv will be created in file_dirzipped_refprepd_taskout
+		# if indexing the decontam ref, the file remove_contam_metadata.tsv will be in tar_refprepd
+		File    tar_refprepd = glob("*.tar")[0]
 		File    debug_workdir = "workdir.txt"
 	}
 }

--- a/tasks/refprep.wdl
+++ b/tasks/refprep.wdl
@@ -74,7 +74,7 @@ task reference_prepare {
 
 		clockwork reference_prepare --outdir ~{outdir} ~{arg_ref} ~{arg_cortex_mem_height} ~{arg_tsv} ~{arg_name}
 
-		tar cf - ~{outdir}/
+		tar -c ~{outdir}/ > ~{outdir}.tar
 
 		ls -lhaR > workdir.txt
 	>>>

--- a/tasks/refprep.wdl
+++ b/tasks/refprep.wdl
@@ -14,22 +14,22 @@ version 1.0
 #	--se_list /cromwell_root/ref_dir/ref.fofn --max_read_len 10000 \
 #	--dump_binary /cromwell_root/ref_dir/ref.k31.ctx --sample_id REF
 
-# * TODO: previously assumed that if FILE_LONESOME_reference_TASKIN, then don't input FILE_LONESOME_tsv_TASKIN, but
-#   is that actually true? --> seems unlikely, could probably use FILE_LONESOME_reference_TASKIN for an
+# * TODO: previously assumed that if reference_fa_file, then don't input FILE_LONESOME_tsv_TASKIN, but
+#   is that actually true? --> seems unlikely, could probably use reference_fa_file for an
 #   index decontamination run which does need a tsv someway or another
 
 task reference_prepare {
 	input {
 		# You need to define either this...
-		File? FILE_LONESOME_reference_TASKIN
+		File? reference_fa_file
 
 		# Or both of these.
-		File?   FILE_DIRZIPPD_reference_TASKIN  # download_tb_reference_files.FILE_DIRZIPPD_tbref_taskout
-		String? STRG_FILENAME_reference_TASKIN  # "remove_contam.fa.gz" or "NC_000962.3.fa"
+		File?   reference_folder     # download_tb_reference_files.tar_tb_ref_raw
+		String? reference_fa_string  # "remove_contam.fa.gz" or "NC_000962.3.fa"
 
 		# If you are indexing the decontamination reference, you need to define
 		# one of these two. It is assumed that if STRG_FILENAME_tsv_TASKIN is defined, the
-		# TSV is located inside FILE_DIRZIPPD_reference_TASKIN, and its path will be
+		# TSV is located inside reference_folder, and its path will be
 		# constructed as "~{dirnozip_reference}/~{STRG_FILENAME_tsv_TASKIN}"
 		File?   FILE_LONESOME_tsv_TASKIN
 		String? STRG_FILENAME_tsv_TASKIN
@@ -47,37 +47,34 @@ task reference_prepare {
 		Int preempt  = 1
 	}
 	# estimate disk size required
-	Int size_in = select_first([ceil(size(FILE_DIRZIPPD_reference_TASKIN, "GB")), ceil(size(FILE_LONESOME_reference_TASKIN, "GB")), 0])
+	Int size_in = select_first([ceil(size(reference_folder, "GB")), ceil(size(reference_fa_file, "GB")), 0])
 	Int finalDiskSize = ceil(2*size_in + addldisk)
 
 	# find where the reference TSV is going to be located, if it exists at all
 	# excessive usage of select_first() is required due to basename() and sub() not working on optional types, even if setting an optional variable
 	String is_there_any_tsv = select_first([STRG_FILENAME_tsv_TASKIN, FILE_LONESOME_tsv_TASKIN, "false"])
-	String? basename_reference = basename(select_first([FILE_DIRZIPPD_reference_TASKIN, "bogus fallback value"]))
-	String? basestem_reference = sub(select_first([basename_reference, "bogus fallback value"]), "\.zip(?!.{5,})", "") # TODO: double check the regex
+	String basestem_reference = sub(basename(select_first([DIRZIPPD_decontam_ref, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
 	String? intermed_tsv1 = if defined(STRG_FILENAME_tsv_TASKIN) then "~{basestem_reference}/~{STRG_FILENAME_tsv_TASKIN}" else ""
 	String? intermed_tsv2 = if defined(FILE_LONESOME_tsv_TASKIN) then "~{FILE_LONESOME_tsv_TASKIN}" else ""
 	String? arg_tsv               = if is_there_any_tsv == "false" then "" else "--contam_tsv ~{intermed_tsv1}~{intermed_tsv2}"
 	
 	# calculate the remaining arguments
-	String arg_ref               = if defined(FILE_LONESOME_reference_TASKIN) then "~{FILE_LONESOME_reference_TASKIN}" else "~{basestem_reference}/~{STRG_FILENAME_reference_TASKIN}"
+	String arg_ref               = if defined(reference_fa_file) then "~{reference_fa_file}" else "~{basestem_reference}/~{reference_fa_string}"
 	String arg_cortex_mem_height = if defined(cortex_mem_height) then "--cortex_mem_height ~{cortex_mem_height}" else ""
 	String arg_name              = if defined(name) then "--name ~{name}" else ""
 
 	command <<<
 		set -eux -o pipefail
 
-		apt-get install pigz -y  # zip has forced my hand
-
-		if [[ ! "~{FILE_DIRZIPPD_reference_TASKIN}" = "" ]]
+		if [[ ! "~{reference_folder}" = "" ]]
 		then
-			cp ~{FILE_DIRZIPPD_reference_TASKIN} .
-			unzip ~{basename_reference}
+			cp ~{reference_folder} .
+			tar -xvf ~{basestem_reference}.tar
 		fi
 
 		clockwork reference_prepare --outdir ~{outdir} ~{arg_ref} ~{arg_cortex_mem_height} ~{arg_tsv} ~{arg_name}
 
-		tar cf - ~{outdir}/ | pigz --fast > ~{outdir}.tar.gz
+		tar cf - ~{outdir}/
 
 		ls -lhaR > workdir.txt
 	>>>
@@ -91,7 +88,7 @@ task reference_prepare {
 		preemptible: "${preempt}"
 	}
 	output {
-		File    file_dirzipped_refprepd_taskout = glob("*.tar.gz")[0]
+		File    file_dirzipped_refprepd_taskout = glob("*.tar")[0]
 		String  STRG_FILENAME_refprepd_taskout = "ref.fa" # seems to always be this
 		# it is assumed that if indexing the decontam ref, the file remove_contam_metadata.tsv will be created in file_dirzipped_refprepd_taskout
 		File    debug_workdir = "workdir.txt"

--- a/tasks/remove-contam.wdl
+++ b/tasks/remove-contam.wdl
@@ -56,7 +56,6 @@ task remove_contam {
 	if [[ ! "~{DIRZIPPD_decontam_ref}" = "" ]]
 	then
 		cp ~{DIRZIPPD_decontam_ref} .
-		gunzip ~{basestem_reference}.tar.gz # could also use pigs for this, not sure if it'd actually be faster
 		tar -xvf ~{basestem_reference}.tar
 	fi
 

--- a/tasks/remove-contam.wdl
+++ b/tasks/remove-contam.wdl
@@ -37,7 +37,7 @@ task remove_contam {
 	String arg_reads_out2 = if(defined(reads_out_2)) then "~{reads_out_2}" else "~{intermed_basestem_bamin}.decontam_2.fq.gz"
 
 	# the metadata TSV will be either be passed in directly, or will be zipped in DIRZIPPD_decontam_ref
-	String basestem_reference = sub(basename(select_first([DIRZIPPD_decontam_ref, "bogus fallback value"])), "\.tar.gz(?!.{5,})", "") # TODO: double check the regex
+	String basestem_reference = sub(basename(select_first([DIRZIPPD_decontam_ref, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
 	String arg_metadata_tsv = if(defined(DIRZIPPD_decontam_ref)) then "~{basestem_reference}/~{FILENAME_metadata_tsv}" else "~{metadata_tsv}"
 	
 	# calculate the optional inputs

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -28,7 +28,8 @@ task variant_call_one_sample {
 	Int size_in = ceil(size(reads_files, "GB")) + addldisk
 	Int finalDiskSize = ceil(2*size_in + addldisk)
 
-	String basestem_ref_dir = sub(basename(select_first([ref_dir, "bogus fallback value"])), "\.tar.gz(?!.{5,})", "") # TODO: double check the regex
+	String basename_sample = sub(basename(select_first([sample_name, "unnamed"])), "\.sam(?!.{5,})", "") # TODO: double check the regex
+	String basestem_ref_dir = sub(basename(select_first([ref_dir, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
 	
 	# generate command line arguments
 	String arg_sample_name = if(defined(sample_name)) then "--sample_name ~{sample_name}" else ""
@@ -40,7 +41,6 @@ task variant_call_one_sample {
 	
 	command <<<
 	cp ~{ref_dir} .
-	gunzip ~{basestem_ref_dir}.tar.gz
 	tar -xvf ~{basestem_ref_dir}.tar
 
 	clockwork variant_call_one_sample \

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -1,22 +1,8 @@
 version 1.0
 
-#usage: clockwork variant_call_one_sample [options] <ref_dir> <outdir> <reads_fwd.fq> <reads_rev.fq> [reads2_fwd.fq reads2_rev.fq ...]
-#
-#Runs the clockwork variant calling pipeline on a single sample. Can provide more than one run of reads from the same sample - if you do this then the reads are all
-#used together, treated as if they were all from one big run. This is for convenience to save catting fastq files.
-#
-#positional arguments:
-#  ref_dir            
-#  outdir             
-#  reads_files        
-#
-#optional arguments:
-#  -h, --help         show this help message and exit
-#  --sample_name STR  Name of sample [sample]
-#  --mem_height INT    [22]
-#  --force            
-#  --keep_bam         
-#  --debug            
+# Runs the clockwork variant calling pipeline on a single sample.
+# Can provide more than one run of reads from the same sample - if you do this then the reads are all
+# used together, treated as if they were all from one big run.
 
 task variant_call_one_sample {
 	input {
@@ -27,9 +13,9 @@ task variant_call_one_sample {
 		String? sample_name
 		String? outdir
 		Int? mem_height
-		Boolean force = false
+		Boolean force    = false
 		Boolean keep_bam = false
-		Boolean debug = false
+		Boolean debug    = false
 
 		# Runtime attributes
 		Int addldisk = 250

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -15,7 +15,7 @@ task variant_call_one_sample {
 		Int? mem_height
 		Boolean force    = false
 		Boolean keep_bam = false
-		Boolean debug    = false
+		Boolean debug    = true
 
 		# Runtime attributes
 		Int addldisk = 250
@@ -28,12 +28,12 @@ task variant_call_one_sample {
 	Int size_in = ceil(size(reads_files, "GB")) + addldisk
 	Int finalDiskSize = ceil(2*size_in + addldisk)
 
-	String basename_sample = sub(basename(select_first([sample_name, "unnamed"])), "\.sam(?!.{5,})", "") # TODO: double check the regex
+	String basestem_sample = sub(basename(select_first([sample_name, "unnamed"])), "\.sam(?!.{5,})", "") # TODO: double check the regex
 	String basestem_ref_dir = sub(basename(select_first([ref_dir, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
 	
 	# generate command line arguments
-	String arg_sample_name = if(defined(sample_name)) then "--sample_name ~{sample_name}" else ""
-	String arg_outdir = "var_call_" + select_first([outdir, sample_name, "unnamed"])
+	String arg_sample_name = if(defined(sample_name)) then "--sample_name ~{basestem_sample}" else ""
+	String arg_outdir = "var_call_" + select_first([outdir, basestem_sample, "unnamed"])
 	String arg_debug = if(debug) then "--debug" else ""
 	String arg_mem_height = if(defined(mem_height)) then "--mem_height ~{mem_height}" else ""
 	String arg_keep_bam = if(keep_bam) then "--keep_bam" else ""
@@ -48,6 +48,7 @@ task variant_call_one_sample {
 		~{basestem_ref_dir} ~{arg_outdir} \
 		~{sep=" " reads_files}
 
+	ls -lhaR > workdir.txt
 	>>>
 
 	parameter_meta {
@@ -71,8 +72,9 @@ task variant_call_one_sample {
 	}
 
 	output {
-		File vcf_final_call_set = "final.vcf"
-		File vcf_cortex = "cortex.vcf"
-		File vcf_samtools = "samtools.vcf"
+		File vcf_final_call_set = "var_call_~{basestem_sample}/final.vcf"
+		File vcf_cortex = "var_call_~{basestem_sample}/cortex.vcf"
+		File vcf_samtools = "var_call_~{basestem_sample}/samtools.vcf"
+		File debug_workdir = "workdir.txt"
 	}
 }

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -51,7 +51,7 @@ task variant_call_one_sample {
 	>>>
 
 	parameter_meta {
-		ref_dir: "tar.gz'd directory of reference files, made by clockwork reference_prepare"
+		ref_dir: "tar'd directory of reference files, made by clockwork reference_prepare"
 		outdir: "Output directory (must not exist, will be created). Will default to var_call_{sample_name} or var_call_unnamed if not provided."
 		sample_name: "Name of the sample"
 		reads_files: "List of forwards and reverse reads filenames (must provide an even number of files). For a single pair of files: reads_forward.fq reads_reverse.fq. For two pairs of files from the same sample: reads1_forward.fq reads1_reverse.fq reads2_forward.fq reads2_reverse.fq"
@@ -74,6 +74,5 @@ task variant_call_one_sample {
 		File vcf_final_call_set = "final.vcf"
 		File vcf_cortex = "cortex.vcf"
 		File vcf_samtools = "samtools.vcf"
-		File? bam_mapped_reads = "TODO replace this"
 	}
 }

--- a/walkthru-cromwell.json
+++ b/walkthru-cromwell.json
@@ -1,6 +1,6 @@
 {
   "ClockworkWalkthrough.ClockworkRefPrepTB.genome": "../../Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "../../Documents/aaa_test_files/tb/Ref.download.zip",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "../../Documents/aaa_test_files/tb/Ref.download.zip",
   "ClockworkWalkthrough.samples":"SAMEA2534128",
   "ClockworkWalkthrough.map_reads.sample_name":"SAMEA2534128",
   "ClockworkWalkthrough.map_reads.outfile": "oof"

--- a/walkthru-miniwdl.json
+++ b/walkthru-miniwdl.json
@@ -1,6 +1,6 @@
 {
   "ClockworkRefPrepTB.genome": "../../Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
-  "ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "../../Documents/aaa_test_files/tb/Ref.download.zip",
+  "ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "../../Documents/aaa_test_files/tb/Ref.download.zip",
   "ClockworkWalkthrough.samples": "SAMEA2534128",
   "map_reads.sample_name":"SAMEA2534421",
   "map_reads.outfile":"oof",

--- a/walkthru-skip-refdl-terra.json
+++ b/walkthru-skip-refdl-terra.json
@@ -1,6 +1,6 @@
 {
   "ClockworkWalkthrough.samples":["SAMEA2534421","SAMEA2534128"],
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "gs://fc-9f0bdb6d-155d-41bc-90af-35ef59252ff8/Ref.download.zip",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "gs://fc-9f0bdb6d-155d-41bc-90af-35ef59252ff8/Ref.download.zip",
   "ClockworkWalkthrough.enaDataGet.preempt":"2",
   "ClockworkWalkthrough.map_reads_quick.cpu":"8",
   "ClockworkWalkthrough.map_reads_quick.disk":"100",

--- a/walkthru-skip-refdl.json
+++ b/walkthru-skip-refdl.json
@@ -1,4 +1,4 @@
 {
   "ClockworkWalkthrough.samples":["SAMEA2534421","SAMEA2534128"],
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip"
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip"
 }

--- a/walkthru-skip-refprep-and-ena.json
+++ b/walkthru-skip-refprep-and-ena.json
@@ -1,10 +1,8 @@
 {
   "ClockworkWalkthrough.ClockworkRefPrepTB.genome": "/Users/ash/Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__file_indxdH37Rvref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout":"ref.fa",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__decontam_STRG_FILENAME_refprepd_taskout":"ref.fa",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__tar_indexed_H37Rv_ref":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__tar_indexd_dcontm_ref":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
   "ClockworkWalkthrough.samples":["SAMEA2534421","SAMEA2534128"],
   "ClockworkWalkthrough.bluepeter__fastqs": [[
     "/Users/ash/Documents/aaa_test_files/tb/local_outs/SAMEA2534128/10527-05_lib727_hpi_2013-11-11_150bp_R1.fastq.gz",

--- a/walkthru-skip-refprep-and-ena.json
+++ b/walkthru-skip-refprep-and-ena.json
@@ -1,6 +1,6 @@
 {
   "ClockworkWalkthrough.ClockworkRefPrepTB.genome": "/Users/ash/Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__file_indxdH37Rvref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout":"ref.fa",

--- a/walkthru-skip-refprep.json
+++ b/walkthru-skip-refprep.json
@@ -1,8 +1,6 @@
 {
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__file_indxdH37Rvref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout":"ref.fa",
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__decontam_STRG_FILENAME_refprepd_taskout":"ref.fa",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__tar_indexed_H37Rv_ref":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__tar_indexd_dcontm_ref":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
   "ClockworkWalkthrough.samples":["SAMEA2534421","SAMEA2534128"],
 }

--- a/walkthru-skip-refprep.json
+++ b/walkthru-skip-refprep.json
@@ -1,5 +1,5 @@
 {
-  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
+  "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__file_indxdH37Rvref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout":"/Users/ash/Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
   "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout":"ref.fa",

--- a/walkthru.wdl
+++ b/walkthru.wdl
@@ -75,7 +75,7 @@ workflow ClockworkWalkthrough {
 		call clockwork_varcalloneTask.variant_call_one_sample {
 			input:
 				sample_name = sam_file,
-				ref_dir = ClockworkRefPrepTB.tar_indexed_H37Rv_ref,
+				ref_dir = ClockworkRefPrepTB.tar_indexd_H37Rv_ref,
 				reads_files = [remove_contamination.decontaminated_fastq_1, remove_contamination.decontaminated_fastq_2]
 
 

--- a/walkthru.wdl
+++ b/walkthru.wdl
@@ -8,7 +8,7 @@ version 1.0
 # * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout"
 # * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__decontam_STRG_FILENAME_refprepd_taskout"
 #
-# You can skip enaDataGetTask.enaDataGet by defining the following as an array
+# You can skip ena.enaDataGet by defining the following as an array
 # of arrays where each inner array corresponds with a sample in samples:
 # * "ClockworkWalkthrough.bluepeter__fastqs"
 #
@@ -17,12 +17,12 @@ version 1.0
 
 #import "./wf-refprep-TB.wdl" as clockwork_refprepWF
 #import "./tasks/mapreads.wdl" as clockwork_mapreadsTask
-#import "../enaBrowserTools-wdl/tasks/enaDataGet.wdl" as enaDataGetTask
+#import "../enaBrowserTools-wdl/tasks/enaDataGet.wdl" as ena
 #import "./tasks/remove-contam.wdl" as clockwork_removecontamTask
 
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/wf-refprep-TB.wdl" as clockwork_refprepWF
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/mapreads.wdl" as clockwork_mapreadsTask
-import "https://raw.githubusercontent.com/aofarrel/enaBrowserTools-wdl/0.0.4/tasks/enaDataGet.wdl" as enaDataGetTask
+import "https://raw.githubusercontent.com/aofarrel/enaBrowserTools-wdl/0.0.4/tasks/enaDataGet.wdl" as ena
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/remove-contam.wdl" as clockwork_removecontamTask
 import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/variant_call_one_sample.wdl" as clockwork_varcalloneTask
 
@@ -41,7 +41,7 @@ workflow ClockworkWalkthrough {
 
 	if(!defined(bluepeter__fastqs)) {
 		scatter(sample in samples) {
-			call enaDataGetTask.enaDataGet {
+			call ena.enaDataGet {
 				input:
 					sample = sample
 			}

--- a/walkthru.wdl
+++ b/walkthru.wdl
@@ -18,11 +18,11 @@ version 1.0
 #import "../enaBrowserTools-wdl/tasks/enaDataGet.wdl" as ena
 #import "./tasks/remove-contam.wdl" as clockwork_removecontamTask
 
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/wf-refprep-TB.wdl" as clockwork_refprepWF
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/mapreads.wdl" as clockwork_mapreadsTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/tar_everything/wf-refprep-TB.wdl" as clockwork_refprepWF
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/tar_everything/tasks/mapreads.wdl" as clockwork_mapreadsTask
 import "https://raw.githubusercontent.com/aofarrel/enaBrowserTools-wdl/0.0.4/tasks/enaDataGet.wdl" as ena
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/remove-contam.wdl" as clockwork_removecontamTask
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/variant_call_one_sample.wdl" as clockwork_varcalloneTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/tar_everything/tasks/remove-contam.wdl" as clockwork_removecontamTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/tar_everything/tasks/variant_call_one_sample.wdl" as clockwork_varcalloneTask
 
 workflow ClockworkWalkthrough {
 	input {

--- a/walkthru.wdl
+++ b/walkthru.wdl
@@ -3,10 +3,8 @@ version 1.0
 # https://github.com/iqbal-lab-org/clockwork/wiki/Walkthrough-scripts-only
 #
 # You can skip clockwork_refprepWF by defining the following:
-# * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__file_indxdH37Rvref_wrkfout"
-# * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout"
-# * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout"
-# * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__decontam_STRG_FILENAME_refprepd_taskout"
+# * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__tar_indexed_H37Rv_ref"
+# * "ClockworkWalkthrough.ClockworkRefPrepTB.bluepeter__tar_indexd_dcontm_ref"
 #
 # You can skip ena.enaDataGet by defining the following as an array
 # of arrays where each inner array corresponds with a sample in samples:
@@ -61,8 +59,8 @@ workflow ClockworkWalkthrough {
 				sample_name = data.left,
 				reads_files = data.right,
 				unsorted_sam = true,
-				DIRZIPPD_reference = ClockworkRefPrepTB.FILE_DIRZIPPD_indxddeconref_wrkfout,
-				FILENAME_reference = ClockworkRefPrepTB.STRG_FILENAME_indxddeconref_wrkfout
+				DIRZIPPD_reference = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
+				FILENAME_reference = "ref.fa"
 		}
 	}
 
@@ -71,13 +69,13 @@ workflow ClockworkWalkthrough {
 		call clockwork_removecontamTask.remove_contam as remove_contamination {
 			input:
 				bam_in = sam_file,
-				DIRZIPPD_decontam_ref = ClockworkRefPrepTB.FILE_DIRZIPPD_indxddeconref_wrkfout,
+				DIRZIPPD_decontam_ref = ClockworkRefPrepTB.tar_indexd_dcontm_ref,
 		}
 
 		call clockwork_varcalloneTask.variant_call_one_sample {
 			input:
 				sample_name = sam_file,
-				ref_dir = ClockworkRefPrepTB.file_indxdH37Rvref_wrkfout,
+				ref_dir = ClockworkRefPrepTB.tar_indexed_H37Rv_ref,
 				reads_files = [remove_contamination.decontaminated_fastq_1, remove_contamination.decontaminated_fastq_2]
 
 

--- a/wf-refprep-TB.json
+++ b/wf-refprep-TB.json
@@ -1,4 +1,4 @@
 {
   "ClockworkRefPrepTB.genome": "/Users/ash/Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
-  "ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip"
+  "ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip"
 }

--- a/wf-refprep-TB.wdl
+++ b/wf-refprep-TB.wdl
@@ -19,13 +19,11 @@ workflow ClockworkRefPrepTB {
 		#
 		# If you define these next two, then download_tb_reference_files will be
 		# skipped, and so will index_H37v_reference.
-		File?   bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout
-		String? bluepeter__decontam_STRG_FILENAME_refprepd_taskout
+		File?   bluepeter__tar_indexd_dcontm_ref
 		#
 		# If you define these last two, then download_tb_reference_files and
 		# will be skipped.
-		File?   bluepeter__file_indxdH37Rvref_wrkfout
-		String? bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout
+		File?   bluepeter__tar_indexd_H37Rv_ref
 		#
 		# Yes, that does mean that the *entire* pipeline can be skipped if the
 		# user inputs the last four inputs, and those four inputs will be considered
@@ -46,7 +44,7 @@ workflow ClockworkRefPrepTB {
 		#  └── remove_contam.tsv
 	}
 
-	if (!defined(bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout)) {
+	if (!defined(bluepeter__tar_indexd_dcontm_ref)) {
 		call refprep.reference_prepare as index_decontamination_ref {
 			input:
 				reference_folder = select_first([bluepeter__download_tb_reference_files__tar_tb_ref_raw,
@@ -56,14 +54,14 @@ workflow ClockworkRefPrepTB {
 				outdir                         = "Ref.remove_contam"
 		}
 		#################### output ####################
-		# Ref.remove_contam.zip
+		# Ref.remove_contam.tar
 		#  ├── ref.fa
 		#  ├── ref.fa.fai
 		#  ├── ref.fa.minimap2_idx
 		#  └── remove_contam_metadata.tsv
 	}
 
-	if (!defined(bluepeter__file_indxdH37Rvref_wrkfout)) {
+	if (!defined(bluepeter__tar_indexd_H37Rv_ref)) {
 		call refprep.reference_prepare as index_H37Rv_reference {
 			input:
 				reference_folder = select_first([bluepeter__download_tb_reference_files__tar_tb_ref_raw,
@@ -72,7 +70,7 @@ workflow ClockworkRefPrepTB {
 				outdir                         = "Ref.H37Rv"
 		}
 		#################### output ####################
-		# Ref.H37Rv.zip
+		# Ref.H37Rv.tar
 		#  ├── ref.fa
 		#  ├── ref.fa.fai
 		#  ├── ref.fa.minimap2_idx
@@ -80,19 +78,11 @@ workflow ClockworkRefPrepTB {
 	}
 
 	output {
-		File   FILE_DIRZIPPD_indxddeconref_wrkfout    = select_first([bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout,
-														index_decontamination_ref.file_dirzipped_refprepd_taskout])
+		File   tar_indexd_dcontm_ref    = select_first([bluepeter__tar_indexd_dcontm_ref,
+														index_decontamination_ref.tar_refprepd])
 		
-		String STRG_FILENAME_indxddeconref_wrkfout    = select_first([bluepeter__decontam_STRG_FILENAME_refprepd_taskout,
-														index_decontamination_ref.STRG_FILENAME_refprepd_taskout,
-														"ref.fa"])
-		
-		File   file_indxdH37Rvref_wrkfout             = select_first([bluepeter__file_indxdH37Rvref_wrkfout,
-														index_H37Rv_reference.file_dirzipped_refprepd_taskout])
-		
-		String STRG_FILENAME_indxdH37Rvref_wrkfout    = select_first([bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout,
-														index_H37Rv_reference.STRG_FILENAME_refprepd_taskout,
-														"ref.fa"])
+		File   tar_indexd_H37Rv_ref     = select_first([bluepeter__tar_indexd_H37Rv_ref,
+														index_H37Rv_reference.tar_refprepd])
 	}
 
 	meta {

--- a/wf-refprep-TB.wdl
+++ b/wf-refprep-TB.wdl
@@ -2,8 +2,8 @@ version 1.0
 #import "./tasks/refprep.wdl"
 #import "./tasks/dl-TB-ref.wdl" as dl_TB_ref
 
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/refprep.wdl"
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/dl-TB-ref.wdl" as dl_TB_ref
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/tar_everything/tasks/refprep.wdl"
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/tar_everything/tasks/dl-TB-ref.wdl" as dl_TB_ref
 
 # correspond with https://github.com/iqbal-lab-org/clockwork/wiki/Walkthrough-scripts-only#get-and-index-reference-genomes
 

--- a/wf-refprep-TB.wdl
+++ b/wf-refprep-TB.wdl
@@ -15,7 +15,7 @@ workflow ClockworkRefPrepTB {
 		# These inputs should ONLY be used if you intend on skipping steps, using
 		# "here's one I made earlier" inputs.
 		# The first two skip the download of the TB reference files.
-		File?   bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout
+		File?   bluepeter__download_tb_reference_files__tar_tb_ref_raw
 		#
 		# If you define these next two, then download_tb_reference_files will be
 		# skipped, and so will index_H37v_reference.
@@ -35,10 +35,10 @@ workflow ClockworkRefPrepTB {
 		# files where you expect them to go) getting tested.
 	}
 
-	if (!defined(bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout)) {
+	if (!defined(bluepeter__download_tb_reference_files__tar_tb_ref_raw)) {
 		call dl_TB_ref.download_tb_reference_files
 		#################### output ####################
-		# Ref.download.zip
+		# Ref.download.tar
 		#  ├── NC_000962.1.fa
 		#  ├── NC_000962.2.fa
 		#  ├── NC_000962.3.fa
@@ -49,11 +49,11 @@ workflow ClockworkRefPrepTB {
 	if (!defined(bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout)) {
 		call refprep.reference_prepare as index_decontamination_ref {
 			input:
-				FILE_DIRZIPPD_reference_TASKIN = select_first([bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout,
-													download_tb_reference_files.FILE_DIRZIPPD_tbref_taskout]),
-				STRG_FILENAME_reference_TASKIN = "remove_contam.fa.gz",
+				reference_folder = select_first([bluepeter__download_tb_reference_files__tar_tb_ref_raw,
+													download_tb_reference_files.tar_tb_ref_raw]),
+				reference_fa_string = "remove_contam.fa.gz",
 				STRG_FILENAME_tsv_TASKIN       = "remove_contam.tsv",
-				outdir    = "Ref.remove_contam"
+				outdir                         = "Ref.remove_contam"
 		}
 		#################### output ####################
 		# Ref.remove_contam.zip
@@ -66,10 +66,10 @@ workflow ClockworkRefPrepTB {
 	if (!defined(bluepeter__file_indxdH37Rvref_wrkfout)) {
 		call refprep.reference_prepare as index_H37Rv_reference {
 			input:
-				FILE_DIRZIPPD_reference_TASKIN = select_first([bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout,
-													download_tb_reference_files.FILE_DIRZIPPD_tbref_taskout]),
-				STRG_FILENAME_reference_TASKIN = "NC_000962.3.fa",
-				outdir    = "Ref.H37Rv"
+				reference_folder = select_first([bluepeter__download_tb_reference_files__tar_tb_ref_raw,
+													download_tb_reference_files.tar_tb_ref_raw]),
+				reference_fa_string = "NC_000962.3.fa",
+				outdir                         = "Ref.H37Rv"
 		}
 		#################### output ####################
 		# Ref.H37Rv.zip

--- a/wf-refprep-bluepeter.json
+++ b/wf-refprep-bluepeter.json
@@ -1,8 +1,6 @@
 {
   "ClockworkRefPrepTB.genome": "../../Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
   "ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
-  "ClockworkRefPrepTB.bluepeter__file_indxdH37Rvref_wrkfout":"../../Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
-  "ClockworkRefPrepTB.bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout":"../../Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
-  "ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout":"ref.fa",
-  "ClockworkRefPrepTB.bluepeter__decontam_STRG_FILENAME_refprepd_taskout":"ref.fa"
+  "ClockworkRefPrepTB.bluepeter__tar_indexed_H37Rv_ref":"../../Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
+  "ClockworkRefPrepTB.bluepeter__tar_indexd_dcontm_ref":"../../Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip"
 }

--- a/wf-refprep-bluepeter.json
+++ b/wf-refprep-bluepeter.json
@@ -1,6 +1,6 @@
 {
   "ClockworkRefPrepTB.genome": "../../Documents/aaa_test_files/tb/H37Rv_version_3_refgenome_NC_000962.3.fasta",
-  "ClockworkRefPrepTB.bluepeter__download_tb_reference_files__FILE_DIRZIPPD_tbref_taskout": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
+  "ClockworkRefPrepTB.bluepeter__download_tb_reference_files__tar_tb_ref_raw": "/Users/ash/Documents/aaa_test_files/tb/Ref.download.zip",
   "ClockworkRefPrepTB.bluepeter__file_indxdH37Rvref_wrkfout":"../../Documents/aaa_test_files/tb/terra_outs/Ref.H37Rv.zip",
   "ClockworkRefPrepTB.bluepeter__FILE_DIRZIPPD_indxddeconref_wrkfout":"../../Documents/aaa_test_files/tb/terra_outs/Ref.remove_contam.zip",
   "ClockworkRefPrepTB.bluepeter__H37Rv_STRG_FILENAME_refprepd_taskout":"ref.fa",


### PR DESCRIPTION
Zipping's cost savings aren't worth the compute time. Tar is the better way to move files around.

Tar is pretty sticky, and it got rid of some dust along the way too. There's now less variables involving the filenames of references that always end up with the same name, and the variables that do remain now have more sensible titles. Also included is a fix for variant_call_one_sample globbing the wrong/no outputs.