### PR TITLE
Sort by name

### DIFF
--- a/tasks/map_reads.wdl
+++ b/tasks/map_reads.wdl
@@ -17,11 +17,9 @@ version 1.0
 
 task map_reads {
 	input {
-		String      sample_name
 		File        tarball_ref_fasta_and_index
 		String      ref_fasta_filename
 		Array[File] reads_files
-		String      outfile      = "~{sample_name}.sam"
 		Boolean     unsorted_sam = false
 		Int?        threads
 
@@ -31,6 +29,10 @@ task map_reads {
 		Int memory = 8
 		Int preempt = 2
 	}
+	String sample_name = sub(reads_files[0], "_1.fastq", "")
+	String outfile     = "~{sample_name}.sam"
+
+
 	String basestem_reference = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{ref_fasta_filename}"

--- a/tasks/map_reads.wdl
+++ b/tasks/map_reads.wdl
@@ -32,7 +32,6 @@ task map_reads {
 	String sample_name = sub(reads_files[0], "_1.fastq", "")
 	String outfile     = "~{sample_name}.sam"
 
-
 	String basestem_reference = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{ref_fasta_filename}"

--- a/tasks/map_reads.wdl
+++ b/tasks/map_reads.wdl
@@ -29,7 +29,7 @@ task map_reads {
 		Int memory = 8
 		Int preempt = 2
 	}
-	String sample_name = sub(reads_files[0], "_1.fastq", "")
+	String sample_name = sub(basename(reads_files[0]), "_1.fastq", "")
 	String outfile     = "~{sample_name}.sam"
 
 	String basestem_reference = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")  # TODO: double check the regex

--- a/tasks/map_reads.wdl
+++ b/tasks/map_reads.wdl
@@ -25,8 +25,8 @@ task map_reads {
 
 		# runtime attributes
 		Int addldisk = 100
-		Int cpu = 4
-		Int memory = 8
+		Int cpu = 8
+		Int memory = 16
 		Int preempt = 2
 	}
 	String sample_name = sub(basename(reads_files[0]), "_1.fastq", "")

--- a/tasks/map_reads.wdl
+++ b/tasks/map_reads.wdl
@@ -1,17 +1,19 @@
 version 1.0
-# The original clockwork function being replicated here would normally take in
-# a ref_fasta file and a ref_index file. But WDL 1.0 cannot pass around directories,
-# so we are anticipating this being given a zipped directory. As such, instead
-# of having a directory containing ref_fasta in our workdir and having the ref_fasta
-# argument tell us exactly where ref_fasta is located, we have to instead:
-# 1. Take in the zipped directory + the basename of ref_fasta
-# 2. Get the basename of the zipped dir without the .zip extension or preceding folders,
-#    which tells us the basename of the dir we want in our workdir
-# 3. Combine that dir basename with the filename of the fasta
-# 4. Begin executing the actual task and localize the zipped dir
-# 5. Copy the zipped dir into the workdir
-# 6. Unzip the workdir copy
-# 7. Actually run the task
+# Important notes:
+# A. This step is usually used not to map reads to the reference genome per say, but
+#    for mapping to a decontamination reference in preparation for generating
+#    decontaminated reads.
+# B. The original clockwork function being replicated here would normally take in
+#    a ref_fasta file and a ref_index file. But WDL 1.0 cannot pass around folders,
+#    so we are anticipating this being given a tarball. This is how it works:
+#       1. Take in the tarball + the basename of ref_fasta
+#       2. Get the basename of the tarball without the .tar extension or preceding folders,
+#          which tells us the basename of the dir we want in our workdir
+#       3. Combine that dir basename with the filename of the fasta
+#       4. Begin executing the actual task and localize the tarball
+#       5. Move the tarball into the workdir and untar it
+#       6. Actually run the task
+#   Note that this task assumes the tarball is NOT gzip compressed.
 
 task map_reads {
 	input {
@@ -48,10 +50,10 @@ task map_reads {
 	echo "outfile" ~{outfile}
 	echo "arg_ref_fasta" ~{arg_ref_fasta}
 	
-	# we need to copy it to the workdir, then untar the copy, or else the ref index won't be found
+	# we need to mv it to the workdir, then untar, or else the ref index won't be found
 	if [[ ! "~{tarball_ref_fasta_and_index}" = "" ]]
 	then
-		cp ~{tarball_ref_fasta_and_index} .
+		mv ~{tarball_ref_fasta_and_index} .
 		tar -xvf ~{basestem_reference}.tar
 	fi
 

--- a/tasks/ref_prep.wdl
+++ b/tasks/ref_prep.wdl
@@ -74,9 +74,10 @@ task reference_prepare {
 
 		clockwork reference_prepare --outdir ~{outdir} ~{arg_ref} ~{arg_cortex_mem_height} ~{arg_tsv} ~{arg_name}
 
+		ls -lhaR > workdir.txt
+
 		tar -c ~{outdir}/ > ~{outdir}.tar
 
-		ls -lhaR > workdir.txt
 	>>>
 	
 	runtime {

--- a/tasks/rm_contam.wdl
+++ b/tasks/rm_contam.wdl
@@ -72,20 +72,16 @@ task remove_contam {
 	then
 		mv ~{tarball_metadata_tsv} .
 		tar -xvf ~{basename_tsv}.tar
-		samtools index ~{bam_in}
 	fi
 
 	if [[ ! "~{metadata_tsv}" = "" ]]
 	then
-		# for some reason it seems this requires a samtools index
-		# TODO: see if the other version also needs it; 
-		# if so this has been broken for a while
 		cp ~{metadata_tsv} .
-		samtools index ~{bam_in}
 	fi
 
-	# debug
-	ls
+	# debug - this might not always be needed
+	#samtools index ~{bam_in} # TODO: check if no index file warning persists while testing sorted sam
+	samtools sort -n ~{bam_in} > sorted_by_read_name_~{intermed_basestem_bamin}.sam
 
 	clockwork remove_contam \
 		~{arg_metadata_tsv} \

--- a/tasks/rm_contam.wdl
+++ b/tasks/rm_contam.wdl
@@ -85,7 +85,7 @@ task remove_contam {
 
 	clockwork remove_contam \
 		~{arg_metadata_tsv} \
-		~{bam_in} \
+		sorted_by_read_name_~{intermed_basestem_bamin}.sam \
 		~{arg_counts_out} \
 		~{arg_reads_out1} \
 		~{arg_reads_out2} \

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -58,6 +58,9 @@ task variant_call_one_sample {
 		~{arg_sample_name} ~{arg_debug} ~{arg_mem_height} ~{arg_keep_bam} ~{arg_force} \
 		~{basestem_ref_dir} ~{arg_outdir} \
 		~{sep=" " reads_files}
+	mv var_call_~{basestem_sample}/final.vcf ./~{basestem_sample}_final.vcf
+	mv var_call_~{basestem_sample}/cortex.vcf ./~{basestem_sample}_cortex.vcf
+	mv var_call_~{basestem_sample}/samtools.vcf ./~{basestem_sample}_samtools.vcf
 
 	ls -lhaR > workdir.txt
 	>>>
@@ -72,9 +75,9 @@ task variant_call_one_sample {
 	}
 
 	output {
-		File vcf_final_call_set = "var_call_~{basestem_sample}/final.vcf"
-		File vcf_cortex = "var_call_~{basestem_sample}/cortex.vcf"
-		File vcf_samtools = "var_call_~{basestem_sample}/samtools.vcf"
+		File vcf_final_call_set = "~{basestem_sample}_final.vcf"
+		File vcf_cortex = "~{basestem_sample}_cortex.vcf"
+		File vcf_samtools = "~{basestem_sample}_samtools.vcf"
 		File debug_workdir = "workdir.txt"
 	}
 }

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -79,7 +79,7 @@ task variant_call_one_sample {
 	}
 
 	output {
-		File mapped_to_ref = glob("~{var_call_SRR1169242}/*.bam")[0]
+		File mapped_to_ref = glob("~{basestem_sample}/*.bam")[0]
 		File vcf_final_call_set = "~{basestem_sample}_final.vcf"
 		File vcf_cortex = "~{basestem_sample}_cortex.vcf"
 		File vcf_samtools = "~{basestem_sample}_samtools.vcf"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -66,7 +66,7 @@ task variant_call_one_sample {
 
 	# debugging stuff
 	ls -lhaR > workdir.txt
-	tar -c ~{basestem_sample}/ > ~{basestem_sample}.tar
+	tar -c var_call_~{basestem_sample}/ > ~{basestem_sample}.tar
 	>>>
 
 	runtime {
@@ -79,7 +79,7 @@ task variant_call_one_sample {
 	}
 
 	output {
-		File mapped_to_ref = glob("~{basestem_sample}/*.bam")[0]
+		File mapped_to_ref = glob("var_call_~{basestem_sample}/*.bam")[0]
 		File vcf_final_call_set = "~{basestem_sample}_final.vcf"
 		File vcf_cortex = "~{basestem_sample}_cortex.vcf"
 		File vcf_samtools = "~{basestem_sample}_samtools.vcf"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -70,6 +70,22 @@ task variant_call_one_sample {
 	# debugging stuff
 	ls -lhaR > workdir.txt
 	tar -c var_call_~{basestem_sample}/ > ~{basestem_sample}.tar
+	head -22 var_call_~{basestem_sample}/cortex/cortex.log | tail -1 > $CORTEX_WARNING
+	CORTEX_WARNING=$(head -22 var_call_~{basestem_sample}/cortex/cortex.log | tail -1)
+	if [[ $CORTEX_WARNING == WARNING* ]] ;
+	then
+		echo "***********"
+		echo "This sample threw a warning during cortex's clean binaries step. This likely means it's too small for variant calling. Expect this task to have errored at minos adjudicate."
+		echo "Read 1 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.1.fq.gz | awk '{print $5}')"
+		echo "Read 2 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.2.fq.gz | awk '{print $5}')"
+		pigz -dk var_call_~{basestem_sample}/trimmed_reads.0.2.fq.gz
+		echo "Decompressed read 2 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.2.fq | awk '{print $5}')"
+		echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
+		head -50 var_call_~{basestem_sample}/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp
+		echo "***********"
+	else
+		echo "This sample likely didn't throw a warning during cortex's clean binaries step. If this task errors out, open an issue on GitHub so the dev can see what's going on!"
+	fi
 	>>>
 
 	runtime {

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -64,7 +64,9 @@ task variant_call_one_sample {
 	mv var_call_~{basestem_sample}/cortex.vcf ./~{basestem_sample}_cortex.vcf
 	mv var_call_~{basestem_sample}/samtools.vcf ./~{basestem_sample}_samtools.vcf
 
+	# debugging stuff
 	ls -lhaR > workdir.txt
+	tar -c ~{basestem_sample}/ > ~{basestem_sample}.tar
 	>>>
 
 	runtime {
@@ -77,10 +79,11 @@ task variant_call_one_sample {
 	}
 
 	output {
-		File mapped_to_ref = glob("*.bam")[0]
+		File mapped_to_ref = glob("~{var_call_SRR1169242}/*.bam")[0]
 		File vcf_final_call_set = "~{basestem_sample}_final.vcf"
 		File vcf_cortex = "~{basestem_sample}_cortex.vcf"
 		File vcf_samtools = "~{basestem_sample}_samtools.vcf"
 		File debug_workdir = "workdir.txt"
+		File debug_tarball = "~{basestem_sample}.tar"
 	}
 }

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -78,10 +78,10 @@ task variant_call_one_sample {
 		echo "This sample threw a warning during cortex's clean binaries step. This likely means it's too small for variant calling. Expect this task to have errored at minos adjudicate."
 		echo "Read 1 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.1.fq.gz | awk '{print $5}')"
 		echo "Read 2 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.2.fq.gz | awk '{print $5}')"
-		pigz -dk var_call_~{basestem_sample}/trimmed_reads.0.2.fq.gz
+		gunzip -dk var_call_~{basestem_sample}/trimmed_reads.0.2.fq.gz
 		echo "Decompressed read 2 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.2.fq | awk '{print $5}')"
 		echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
-		head -50 var_call_~{basestem_sample}/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp
+		head -50 var_call_~{basestem_sample}/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
 		echo "***********"
 	else
 		echo "This sample likely didn't throw a warning during cortex's clean binaries step. If this task errors out, open an issue on GitHub so the dev can see what's going on!"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -64,6 +64,9 @@ task variant_call_one_sample {
 	mv var_call_~{basestem_sample}/cortex.vcf ./~{basestem_sample}_cortex.vcf
 	mv var_call_~{basestem_sample}/samtools.vcf ./~{basestem_sample}_samtools.vcf
 
+	# rename the bam file to the basestem
+	mv var_call_~{basestem_sample}/map.bam ./~{basestem_sample}_to_~{basestem_ref_dir}.bam
+
 	# debugging stuff
 	ls -lhaR > workdir.txt
 	tar -c var_call_~{basestem_sample}/ > ~{basestem_sample}.tar
@@ -79,7 +82,7 @@ task variant_call_one_sample {
 	}
 
 	output {
-		File mapped_to_ref = glob("var_call_~{basestem_sample}/*.bam")[0]
+		File mapped_to_ref = "~{basestem_sample}_to_~{basestem_ref_dir}.bam"
 		File vcf_final_call_set = "~{basestem_sample}_final.vcf"
 		File vcf_cortex = "~{basestem_sample}_cortex.vcf"
 		File vcf_samtools = "~{basestem_sample}_samtools.vcf"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -14,7 +14,6 @@ task variant_call_one_sample {
 		String? outdir
 		Int? mem_height
 		Boolean force    = false
-		Boolean keep_bam = false
 		Boolean debug    = true
 
 		# Runtime attributes
@@ -24,6 +23,10 @@ task variant_call_one_sample {
 		Int memory   = 32
 		Int preempt  = 1
 	}
+	# forcing this to be true so we can make mapped_to_ref output non-optional,
+	# which will avoid awkwardness when it comes to passing that to other tasks
+	Boolean keep_bam = true
+
 	# estimate disk size required
 	Int size_in = ceil(size(reads_files, "GB")) + addldisk
 	Int finalDiskSize = ceil(2*size_in + addldisk)
@@ -46,7 +49,6 @@ task variant_call_one_sample {
 		reads_files: "List of forwards and reverse reads filenames (must provide an even number of files). For a single pair of files: reads_forward.fq reads_reverse.fq. For two pairs of files from the same sample: reads1_forward.fq reads1_reverse.fq reads2_forward.fq reads2_reverse.fq"
 		mem_height: "cortex mem_height option. Must match what was used when reference_prepare was run"
 		force: "Overwrite outdir if it already exists"
-		keep_bam: "Keep BAM file of rmdup reads"
 		debug: "Debug mode: do not clean up any files"
 	}
 	
@@ -75,6 +77,7 @@ task variant_call_one_sample {
 	}
 
 	output {
+		File mapped_to_ref = glob("*.bam")[0]
 		File vcf_final_call_set = "~{basestem_sample}_final.vcf"
 		File vcf_cortex = "~{basestem_sample}_cortex.vcf"
 		File vcf_samtools = "~{basestem_sample}_samtools.vcf"

--- a/workflows/refprep-TB.wdl
+++ b/workflows/refprep-TB.wdl
@@ -41,9 +41,10 @@ workflow ClockworkRefPrepTB {
 	if (!defined(bluepeter__tar_indexd_dcontm_ref)) {
 		call ref_prep.reference_prepare as index_decontamination_ref {
 			input:
-				reference_folder = select_first([bluepeter__tar_tb_ref_raw, download_tb_reference_files.tar_tb_ref_raw]),
+				reference_folder = select_first([bluepeter__tar_tb_ref_raw,
+					download_tb_reference_files.tar_tb_ref_raw]),
 				reference_fa_string            = "remove_contam.fa.gz",
-				contam_tsv_in_reference_folder       = "remove_contam.tsv",
+				contam_tsv_in_reference_folder = "remove_contam.tsv",
 				outdir                         = "Ref.remove_contam"
 		}
 
@@ -58,9 +59,9 @@ workflow ClockworkRefPrepTB {
 		call ref_prep.reference_prepare as index_H37Rv_reference {
 			input:
 				reference_folder = select_first([bluepeter__tar_tb_ref_raw,
-													download_tb_reference_files.tar_tb_ref_raw]),
+					download_tb_reference_files.tar_tb_ref_raw]),
 				reference_fa_string = "NC_000962.3.fa",
-				outdir                         = "Ref.H37Rv"
+				outdir              = "Ref.H37Rv"
 		}
 
 		# Ref.H37Rv.tar
@@ -76,6 +77,10 @@ workflow ClockworkRefPrepTB {
 		
 		File   tar_indexd_H37Rv_ref     = select_first([bluepeter__tar_indexd_H37Rv_ref,
 														index_H37Rv_reference.tar_ref_prepd])
+		
+		# This should never fall back to the second one; we select_first only to coerce File? to File
+		File   remove_contam_tsv        = select_first([index_decontamination_ref.remove_contam_tsv,
+														index_decontamination_ref.tar_ref_prepd])
 	}
 
 	meta {

--- a/workflows/walkthru.wdl
+++ b/workflows/walkthru.wdl
@@ -18,11 +18,11 @@ version 1.0
 #import "../enaBrowserTools-wdl/tasks/enaDataGet.wdl" as ena
 #import "./tasks/rm_contam.wdl" as clockwork_removecontamTask
 
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/map_reads.wdl" as clockwork_map_readsTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/sort-by-name/workflows/refprep-TB.wdl" as clockwork_ref_prepWF
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/sort-by-name/tasks/map_reads.wdl" as clockwork_map_readsTask
 import "https://raw.githubusercontent.com/aofarrel/enaBrowserTools-wdl/0.0.4/tasks/enaDataGet.wdl" as ena
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/rm_contam.wdl" as clockwork_removecontamTask
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/variant_call_one_sample.wdl" as clockwork_varcalloneTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/sort-by-name/tasks/rm_contam.wdl" as clockwork_removecontamTask
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/sort-by-name/tasks/variant_call_one_sample.wdl" as clockwork_varcalloneTask
 
 workflow ClockworkWalkthrough {
 	input {


### PR DESCRIPTION
This branch got a little out of hand. Its raison d'etre was to test if sorting sam files would fix issues with data from SRA (data from ENA didn't seem to require doing this). But now it also has:

* a lot of debugging stuff, mostly in the variant caller task
* no longer allows the user to specify sample_name and outfile in map_reads task
* don't samtools index in remove contam task
* map_reads task mvs the ref genome instead of copying it
* comment fixes (some still referenced zips)
* ls -lha happens before attempting to tar in reference preparation task
* map_reads task is now beefier by default
* other tiny tweaks