### PR TITLE
Dupe check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # clockwork-wdl
- An in-progress WDLization of [clockwork](https://github.com/iqbal-lab-org/clockwork), focusing on functions used by [this walkthrough](https://github.com/iqbal-lab-org/clockwork/wiki/Walkthrough-scripts-only). Supports (and sometimes requires) tarball inputs -- please make sure to read the inputs section.
+ A partial WDLization of [clockwork](https://github.com/iqbal-lab-org/clockwork), focusing on functions used by [this walkthrough](https://github.com/iqbal-lab-org/clockwork/wiki/Walkthrough-scripts-only). Supports (and sometimes requires) tarball inputs -- please make sure to read the inputs section.
 
  To allow for quicker runs, several workflows have "bluepeter" options. Named after the TV show coining the term "here's one I made earlier," these are files you can insert when running a workflow more than once in order to avoid downloading the same set of files over and over again.
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -210,7 +210,7 @@ task combined_decontamination_multiple {
 	do
 		basename_ball=$(basename $BALL)
 		sample_name="${basename_ball%%_*}"
-		$sample_name >> list_of_samples.txt
+		echo "$sample_name\n" >> list_of_samples.txt
 	done
 	sort list_of_samples.txt | uniq -d >> dupe_samples.txt
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -220,7 +220,7 @@ task combined_decontamination_multiple {
 		# check for duplicates, part 2
 		# TODO: This will cause a duplicated sample to always get skipped, ie, it won't even
 		# get a first time. Ideally we still want to deal with once (and only once)
-		basename_ball=$(basename $BALL)
+		basename_ball=$(basename $BALL .tar)
 		sample_name="${basename_ball%%_*}"
 		if grep -q "$sample_name" dupe_samples.txt
 		then

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -205,15 +205,17 @@ task combined_decontamination_multiple {
 	# We could use uniq -u to create an allowlist of acceptable
 	# samples, but we still have to deal with tarballs in input
 	# directories.
+	echo "Listing out samples..."
 	touch list_of_samples.txt
 	for BALL in ~{sep=' ' tarballs_of_read_files}
 	do
-		basename_ball=$(basename $BALL)
+		basename_ball=$(basename $BALL .tar)
 		sample_name="${basename_ball%%_*}"
 		echo "$sample_name\n" >> list_of_samples.txt
 	done
 	sort list_of_samples.txt | uniq -d >> dupe_samples.txt
 
+	echo "Now iterating..."
 	for BALL in ~{sep=' ' tarballs_of_read_files}
 	do
 
@@ -225,6 +227,7 @@ task combined_decontamination_multiple {
 		if grep -q "$sample_name" dupe_samples.txt
 		then
 			# skip this sample, go onto the next
+			echo "$sample_name appears to be a duplicate and will be skipped."
 			continue
 		fi
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -230,7 +230,7 @@ task combined_decontamination_multiple {
 
 		# mv read files into workdir and untar them
 		mv $BALL .
-		tar -xvf "$basename_ball"
+		tar -xvf $basename_ball.tar
 
 		# the docker image uses bash v5 so we can use readarray to make an array easily
 		declare -a read_files

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -36,7 +36,7 @@ task combined_decontamination_single {
 	String basestem_reference = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{ref_fasta_filename}"
-	String arg_threads = if defined(threads) then "--threads {threads}" else ""
+	String arg_threads = if defined(threads) then "--threads ~{threads}" else ""
 
 	# the metadata TSV will be zipped in tarball_ref_fasta_and_index
 	String basename_tsv = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -305,7 +305,7 @@ task combined_decontamination_multiple {
 		# to save space, these "debug" outs aren't included in the per sample tarballs
 		Array[File] mapped_to_decontam = glob("*.sam")
 		Array[File] counts = glob("*.counts.tsv")
-		File duplicated_input_files = "dupe_files.txt"
-		File duplicated_input_samples = "dupe_samples.txt"
+		File? duplicated_input_files = "dupe_files.txt"
+		File? duplicated_input_samples = "dupe_samples.txt"
 	}
 }

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -53,6 +53,7 @@ task variant_call_one_sample_simple {
 	command <<<
 	mv ~{ref_dir} .
 	tar -xvf ~{basestem_ref_dir}.tar
+	rm ~{basestem_ref_dir}.tar # just to save disk space
 
 	for READFILE in ~{sep=' ' reads_files} 
 	do
@@ -177,7 +178,9 @@ task variant_call_one_sample_verbose {
 	
 	command <<<
 	mv ~{ref_dir} .
+	tar -xvf ~{basestem_ref_dir}.tar
 	rm ~{basestem_ref_dir}.tar # needs to be deleted to prevent next bit breaking
+
 	if [[ ! "~{tarball_of_reads_files}" = "" ]]
 	then
 		mv ~{tarball_of_reads_files} .

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -46,7 +46,6 @@ task variant_call_one_sample_simple {
 	parameter_meta {
 		ref_dir: "tarball directory of reference files, made by clockwork reference_prepare"
 		outdir: "Output directory (must not exist, will be created). Will default to var_call_{sample_name} or var_call_unnamed if not provided."
-		sample_name: "Name of the sample"
 		reads_files: "List of forwards and reverse reads filenames (must provide an even number of files). For a single pair of files: reads_forward.fq reads_reverse.fq. For two pairs of files from the same sample: reads1_forward.fq reads1_reverse.fq reads2_forward.fq reads2_reverse.fq"
 		mem_height: "cortex mem_height option. Must match what was used when reference_prepare was run"
 		force: "Overwrite outdir if it already exists"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -68,7 +68,7 @@ task variant_call_one_sample_simple {
 	if clockwork variant_call_one_sample \
 		--sample_name $sample_name ~{arg_debug} ~{arg_mem_height} ~{arg_keep_bam} ~{arg_force} \
 		~{basestem_ref_dir} $arg_outdir \
-		~{sep=" " reads_files} then echo "Task completed successfully (probably)"	
+		~{sep=" " reads_files}; then echo "Task completed successfully (probably)"	
 	else	
 		echo "Caught an error."	
 		touch $sample_name	

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -71,13 +71,16 @@ task variant_call_one_sample_simple {
 		~{sep=" " reads_files}
 	
 	tree > tree2.txt
+	workdir=$(pwd)
 
-	mv var_call_$sample_name/final.vcf ./$sample_name_final.vcf
-	mv var_call_$sample_name/cortex.vcf ./$sample_name_cortex.vcf
-	mv var_call_$sample_name/samtools.vcf ./$sample_name_samtools.vcf
+	echo "mv var_call_$sample_name/final.vcf $workdir/$sample_name_final.vcf"
+
+	mv -v var_call_$sample_name/final.vcf $workdir/$sample_name_final.vcf
+	mv -v var_call_$sample_name/cortex.vcf $workdir/$sample_name_cortex.vcf
+	mv -v var_call_$sample_name/samtools.vcf $workdir/$sample_name_samtools.vcf
 
 	# rename the bam file to the basestem
-	mv var_call_$sample_name/map.bam ./$sample_name_to_~{basestem_ref_dir}.bam
+	mv -v var_call_$sample_name/map.bam $workdir/$sample_name_to_~{basestem_ref_dir}.bam
 
 	# debugging stuff
 	head -22 var_call_$sample_name/cortex/cortex.log | tail -1 > $CORTEX_WARNING

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -14,7 +14,6 @@ task variant_call_one_sample_simple {
 		Array[File] reads_files
 
 		# optional args
-		String? outdir
 		Int? mem_height
 		Boolean force    = false
 		Boolean debug    = false
@@ -37,7 +36,6 @@ task variant_call_one_sample_simple {
 	String basestem_ref_dir = sub(basename(select_first([ref_dir, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
 	
 	# generate command line arguments
-	String arg_outdir = "var_call_" + select_first([outdir, "unnamed"])
 	String arg_debug = if(debug) then "--debug" else ""
 	String arg_mem_height = if(defined(mem_height)) then "--mem_height ~{mem_height}" else ""
 	String arg_keep_bam = if(keep_bam) then "--keep_bam" else ""
@@ -45,7 +43,6 @@ task variant_call_one_sample_simple {
 
 	parameter_meta {
 		ref_dir: "tarball directory of reference files, made by clockwork reference_prepare"
-		outdir: "Output directory (must not exist, will be created). Will default to var_call_{sample_name} or var_call_unnamed if not provided."
 		reads_files: "List of forwards and reverse reads filenames (must provide an even number of files). For a single pair of files: reads_forward.fq reads_reverse.fq. For two pairs of files from the same sample: reads1_forward.fq reads1_reverse.fq reads2_forward.fq reads2_reverse.fq"
 		mem_height: "cortex mem_height option. Must match what was used when reference_prepare was run"
 		force: "Overwrite outdir if it already exists"
@@ -66,7 +63,7 @@ task variant_call_one_sample_simple {
 
 	clockwork variant_call_one_sample \
 		--sample_name $sample_name ~{arg_debug} ~{arg_mem_height} ~{arg_keep_bam} ~{arg_force} \
-		~{basestem_ref_dir} ~{arg_outdir} \
+		~{basestem_ref_dir} var_call_$sample_name \
 		~{sep=" " reads_files}
 	mv var_call_$sample_name/final.vcf ./$sample_name_final.vcf
 	mv var_call_$sample_name/cortex.vcf ./$sample_name_cortex.vcf
@@ -119,7 +116,6 @@ task variant_call_one_sample_verbose {
 
 		# optional args
 		String? sample_name # only used in warning_file
-		#String? outdir  --> generated from inputs
 		Int? mem_height
 		Boolean force    = false
 		Boolean debug    = true

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -98,8 +98,6 @@ task variant_call_one_sample_simple {
 		echo "Decompressed read 2 is $(ls -lh var_call_$sample_name/trimmed_reads.0.2.fq | awk '{print $5}')"
 		echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
 		head -50 var_call_$sample_name/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
-		echo "***********"
-		echo "More data please!" > ~{warning_file}.warning
 		exit 0
 	else
 		echo "This sample likely didn't throw a warning during cortex's clean binaries step. If this task errors out, open an issue on GitHub so the dev can see what's going on!"
@@ -125,7 +123,6 @@ task variant_call_one_sample_simple {
 		File debugtree1 = "tree1.txt"
 		File debugtree2 = "tree2.txt"
 		File debugtree3 = "tree3.txt"
-		File? debug_error = "~{warning_file}.warning" # only exists if we error out
 	}
 }
 
@@ -234,6 +231,7 @@ task variant_call_one_sample_verbose {
 		echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
 		head -50 var_call_$sample_name/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
 		echo "***********"
+		echo "More data please!" > "~{warning_file}".warning
 		exit 0
 	else
 		echo "This sample likely didn't throw a warning during cortex's clean binaries step. If this task errors out, open an issue on GitHub so the dev can see what's going on!"
@@ -255,5 +253,6 @@ task variant_call_one_sample_verbose {
 		File? vcf_cortex = glob("*_cortex.vcf")[0]
 		File? vcf_samtools = glob("*_samtools.vcf")[0]
 		File debug_workdir = "workdir.txt"
+		File? debug_error = "~{warning_file}.warning" # only exists if we error out, cannot glob otherwise
 	}
 }

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -60,10 +60,18 @@ task variant_call_one_sample_simple {
 		sample_name="${basename%%.*}"
 	done
 
+	echo $sample_name
+	apt-get install -y tree
+
+	tree > tree1.txt
+
 	clockwork variant_call_one_sample \
 		--sample_name $sample_name ~{arg_debug} ~{arg_mem_height} ~{arg_keep_bam} ~{arg_force} \
 		~{basestem_ref_dir} var_call_$sample_name \
 		~{sep=" " reads_files}
+	
+	tree > tree2.txt
+
 	mv var_call_$sample_name/final.vcf ./$sample_name_final.vcf
 	mv var_call_$sample_name/cortex.vcf ./$sample_name_cortex.vcf
 	mv var_call_$sample_name/samtools.vcf ./$sample_name_samtools.vcf
@@ -88,6 +96,8 @@ task variant_call_one_sample_simple {
 	else
 		echo "This sample likely didn't throw a warning during cortex's clean binaries step. If this task errors out, open an issue on GitHub so the dev can see what's going on!"
 	fi
+
+	tree > tree3.txt
 	>>>
 
 	runtime {
@@ -104,6 +114,9 @@ task variant_call_one_sample_simple {
 		File vcf_final_call_set = glob("*_final.vcf")[0]
 		File vcf_cortex = glob("*_cortex.vcf")[0]
 		File vcf_samtools = glob("*_samtools.vcf")[0]
+		File debugtree1 = "tree1.txt"
+		File debugtree2 = "tree2.txt"
+		File debugtree3 = "tree3.txt"
 	}
 }
 

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -14,7 +14,6 @@ task variant_call_one_sample_simple {
 		Array[File] reads_files
 
 		# optional args
-		String? sample_name
 		String? outdir
 		Int? mem_height
 		Boolean force    = false
@@ -35,12 +34,10 @@ task variant_call_one_sample_simple {
 	Int size_in = ceil(size(reads_files, "GB")) + addldisk
 	Int finalDiskSize = ceil(2*size_in + addldisk)
 
-	String basestem_sample = sub(basename(select_first([sample_name, "unnamed"])), "\.sam(?!.{5,})", "") # TODO: double check the regex
 	String basestem_ref_dir = sub(basename(select_first([ref_dir, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
 	
 	# generate command line arguments
-	String arg_sample_name = if(defined(sample_name)) then "--sample_name ~{basestem_sample}" else ""
-	String arg_outdir = "var_call_" + select_first([outdir, basestem_sample, "unnamed"])
+	String arg_outdir = "var_call_" + select_first([outdir, "unnamed"])
 	String arg_debug = if(debug) then "--debug" else ""
 	String arg_mem_height = if(defined(mem_height)) then "--mem_height ~{mem_height}" else ""
 	String arg_keep_bam = if(keep_bam) then "--keep_bam" else ""
@@ -62,30 +59,36 @@ task variant_call_one_sample_simple {
 	apt-get install -y tree
 	tree > tree.txt
 
+	for READFILE in ~{sep=' ' reads_files} 
+	do
+		basename=$(basename $READFILE .fq.gz)
+		sample_name="${basename%%_*}"
+	done
+
 	clockwork variant_call_one_sample \
-		~{arg_sample_name} ~{arg_debug} ~{arg_mem_height} ~{arg_keep_bam} ~{arg_force} \
+		--sample_name $sample_name ~{arg_debug} ~{arg_mem_height} ~{arg_keep_bam} ~{arg_force} \
 		~{basestem_ref_dir} ~{arg_outdir} \
 		~{sep=" " reads_files}
-	mv var_call_~{basestem_sample}/final.vcf ./~{basestem_sample}_final.vcf
-	mv var_call_~{basestem_sample}/cortex.vcf ./~{basestem_sample}_cortex.vcf
-	mv var_call_~{basestem_sample}/samtools.vcf ./~{basestem_sample}_samtools.vcf
+	mv var_call_$sample_name/final.vcf ./$sample_name_final.vcf
+	mv var_call_$sample_name/cortex.vcf ./$sample_name_cortex.vcf
+	mv var_call_$sample_name/samtools.vcf ./$sample_name_samtools.vcf
 
 	# rename the bam file to the basestem
-	mv var_call_~{basestem_sample}/map.bam ./~{basestem_sample}_to_~{basestem_ref_dir}.bam
+	mv var_call_$sample_name/map.bam ./$sample_name_to_~{basestem_ref_dir}.bam
 
 	# debugging stuff
-	head -22 var_call_~{basestem_sample}/cortex/cortex.log | tail -1 > $CORTEX_WARNING
-	CORTEX_WARNING=$(head -22 var_call_~{basestem_sample}/cortex/cortex.log | tail -1)
+	head -22 var_call_$sample_name/cortex/cortex.log | tail -1 > $CORTEX_WARNING
+	CORTEX_WARNING=$(head -22 var_call_$sample_name/cortex/cortex.log | tail -1)
 	if [[ $CORTEX_WARNING == WARNING* ]] ;
 	then
 		echo "***********"
 		echo "This sample threw a warning during cortex's clean binaries step. This likely means it's too small for variant calling. Expect this task to have errored at minos adjudicate."
-		echo "Read 1 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.1.fq.gz | awk '{print $5}')"
-		echo "Read 2 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.2.fq.gz | awk '{print $5}')"
-		gunzip -dk var_call_~{basestem_sample}/trimmed_reads.0.2.fq.gz
-		echo "Decompressed read 2 is $(ls -lh var_call_~{basestem_sample}/trimmed_reads.0.2.fq | awk '{print $5}')"
+		echo "Read 1 is $(ls -lh var_call_$sample_name/trimmed_reads.0.1.fq.gz | awk '{print $5}')"
+		echo "Read 2 is $(ls -lh var_call_$sample_name/trimmed_reads.0.2.fq.gz | awk '{print $5}')"
+		gunzip -dk var_call_$sample_name/trimmed_reads.0.2.fq.gz
+		echo "Decompressed read 2 is $(ls -lh var_call_$sample_name/trimmed_reads.0.2.fq | awk '{print $5}')"
 		echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
-		head -50 var_call_~{basestem_sample}/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
+		head -50 var_call_$sample_name/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
 		echo "***********"
 	else
 		echo "This sample likely didn't throw a warning during cortex's clean binaries step. If this task errors out, open an issue on GitHub so the dev can see what's going on!"
@@ -102,10 +105,10 @@ task variant_call_one_sample_simple {
 	}
 
 	output {
-		File mapped_to_ref = "~{basestem_sample}_to_~{basestem_ref_dir}.bam"
-		File vcf_final_call_set = "~{basestem_sample}_final.vcf"
-		File vcf_cortex = "~{basestem_sample}_cortex.vcf"
-		File vcf_samtools = "~{basestem_sample}_samtools.vcf"
+		File mapped_to_ref = "$sample_name_to_~{basestem_ref_dir}.bam"
+		File vcf_final_call_set = "$sample_name_final.vcf"
+		File vcf_cortex = "$sample_name_cortex.vcf"
+		File vcf_samtools = "$sample_name_samtools.vcf"
 	}
 }
 
@@ -161,18 +164,19 @@ task variant_call_one_sample_verbose {
 	
 	command <<<
 	mv ~{ref_dir} .
-	tar -xvf ~{basestem_ref_dir}.tar
 	rm ~{basestem_ref_dir}.tar # needs to be deleted to prevent next bit breaking
 	if [[ ! "~{tarball_of_reads_files}" = "" ]]
 	then
 		mv ~{tarball_of_reads_files} .
 		tar -xvf ./*.tar # if another tar is in the workdir this will fail
+		sample_name="$(basename ~{tarball_of_reads_files} .tar)"
 	fi
 	if [[ ! "~{sep=" " reads_files}" = "" ]]
 	then
 		# this should ensure find *.fq.gz works as expected
 		for READFILE in ~{sep=' ' reads_files}
 		do
+			sample_name="$(basename $READFILE .fq.gz)"
 			mv $READFILE .
 		done
 	fi
@@ -180,7 +184,6 @@ task variant_call_one_sample_verbose {
 	ls -lha
 	
 	# get sample name and reads files
-	sample_name="$(basename ~{tarball_of_reads_files} .tar)"
 	declare -a read_files_array
 	readarray -t read_files_array < <(find ./"$sample_name" -name "*.fq.gz")
 	one_read_file=$(echo "${read_files_array[0]}")

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -234,7 +234,6 @@ task variant_call_one_sample_verbose {
 		echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
 		head -50 var_call_$sample_name/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
 		echo "***********"
-		echo "More data please!" > ~{warning_file}.warning
 		exit 0
 	else
 		echo "This sample likely didn't throw a warning during cortex's clean binaries step. If this task errors out, open an issue on GitHub so the dev can see what's going on!"
@@ -256,6 +255,5 @@ task variant_call_one_sample_verbose {
 		File? vcf_cortex = glob("*_cortex.vcf")[0]
 		File? vcf_samtools = glob("*_samtools.vcf")[0]
 		File debug_workdir = "workdir.txt"
-		File? debug_error = "~{warning_file}.warning" # only exists if we error out
 	}
 }


### PR DESCRIPTION
Check for duplicates, and base the output sample name on the tarball input, not the filename of one of the sample's fastq files.

This isn't perfect, because it causes a duplicated sample to never run (even once). But it does seem to avoid errors, and in tandem with SRANWRP's own duplication checking mechanism, gets the job done.