### PR TITLE
Add subsample to decontamination

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -94,8 +94,8 @@ task combined_decontamination_single {
 	then
 		for inputfq in "${READS_FILES[@]}"
 		do
-			size_inputfq=$(du -m "$inputfq")
-			if (( size_inputfq > ~{subsample_cutoff} ))
+			size_inputfq=$(du -m "$inputfq" | cut -f1)
+			if (( $size_inputfq > ~{subsample_cutoff} ))  # shellcheck dislikes, but without $, size_inputfq is unbound
 			then
 				seqtk sample -s~{subsample_seed} "$inputfq" 1000000 > temp.fq
 				rm "$inputfq"

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -91,6 +91,12 @@ task combined_decontamination_single {
 	fi
 
 	# downsample, if necessary
+	#
+	# Downsampling relies on deleting inputs and then putting a new file
+	# where the the old input was. This works on Terra, but there is a
+	# chance this gets iffy on other backends.
+	# If you've issues with miniwdl, --copy-input-files might help
+
 	if [[ "~{subsample_cutoff}" != "-1" ]]
 	then
 		for inputfq in "${READS_FILES[@]}"

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -86,15 +86,15 @@ task combined_decontamination_single {
 	fi
 
 	# downsample, if necessary
-	for inputfq in ${sizes_of_inputfqs[@]}
+	for inputfq in "${READS_FILES[@]}"
 	do
-  		size_of_inputfq=$(du -m $inputfq)
-		if (( size_of_inputfq > ~{subsample_cutoff} ))
+		size_inputfq=$(du -m "$inputfq")
+		if (( size_inputfq > ~{subsample_cutoff} ))
 		then
-			seqtk sample -s~{subsample_seed} $inputfq 1000000 > temp.fq
-			rm $inputfq
-			mv temp.fq $inputfq
-			echo "WARNING: downsampled $inputfq (was $somefastqsize MB)"
+			seqtk sample -s~{subsample_seed} "$inputfq" 1000000 > temp.fq
+			rm "$inputfq"
+			mv temp.fq "$inputfq"
+			echo "WARNING: downsampled $inputfq (was $size_inputfq MB)"
 		fi
 	done
 	

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -1,28 +1,33 @@
 version 1.0
 
 # These tasks combine the rm_contam and map_reads steps into one WDL task.
-# This can save money on most backends.
-
-# tarball_metadata_tsv and tarball_ref_fasta_and_index are the same.
+# This can save money on some backends.
 
 task combined_decontamination_single {
+	# This is the task you probably should be using. It works on one sample.
+	# If you're working on multiple samples, scatter upon this task.
 	input {
+
+		# the important stuff
 		File        tarball_ref_fasta_and_index
 		String      ref_fasta_filename
 		Array[File] reads_files
-		Boolean     unsorted_sam = false
+		String      filename_metadata_tsv = "remove_contam_metadata.tsv"
+
+		# bonus options
+		Int         subsample_cutoff = 450 # subsample if fastq > this value in MB
+		Int         subsample_seed = 1965
 		Int?        threads
+		Boolean     unsorted_sam = false # it's recommend to keep this false
+		Boolean     verbose = true
 
-		String filename_metadata_tsv = "remove_contam_metadata.tsv"
-
-		String? counts_out # MUST end in counts.tsv
+		# rename outs
+		String? counts_out     # must end in counts.tsv
 		String? no_match_out_1
 		String? no_match_out_2
 		String? contam_out_1
 		String? contam_out_2
 		String? done_file
-
-		Boolean verbose = true
 
 		# runtime attributes
 		Int addldisk = 100
@@ -139,6 +144,9 @@ task combined_decontamination_single {
 }
 
 task combined_decontamination_multiple {
+	# This task should be considered deprecated. It's usually more expensive than 
+	# decontaminating via a scattered task and it's more complicated. It also doesn't
+	# support downsampling.
 	input {
 		File        tarball_ref_fasta_and_index
 		String      ref_fasta_filename


### PR DESCRIPTION
Adds the option to subsample when running the decontamination task. This is intended for a new version of myco which can take in an array of files directly, which skips SRANWRP's checks and downsampling.

Also makes some minor formatting improvements to the decontamination task.