### PR TITLE
Add support for combined decontamination timing out after a period of time

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -39,7 +39,7 @@ task combined_decontamination_single {
 
 	# calculate stuff for the map_reads call
 	String read_file_basename = basename(reads_files[0]) # used to calculate sample name + outfile_sam
-	String reads_out_base = sub(read_file_basename, "_\d", "")
+	String reads_out_base = sub(read_file_basename, "_\d.fastq", "")
 	String basestem_reference = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{ref_fasta_filename}"
@@ -211,10 +211,10 @@ task combined_decontamination_single {
 
 	output {
 		#File? mapped_to_decontam = glob("*.sam")[0]
-		File? counts_out_tsv = reads_out_base + "decontam.counts.tsv"
+		File? counts_out_tsv = reads_out_base + ".decontam.counts.tsv"
 		String sample_name = read_string("sample_name.txt")
-		File? decontaminated_fastq_1 = reads_out_base + "decontam_1.fq.gz"
-		File? decontaminated_fastq_2 = reads_out_base + "*decontam_2.fq.gz"
+		File? decontaminated_fastq_1 = reads_out_base + ".decontam_1.fq.gz"
+		File? decontaminated_fastq_2 = reads_out_base + ".decontam_2.fq.gz"
 		File? check_this_samples_fastqs = reads_out_base + "this_is_a_bad_sign"
 		File? check_this_fastq_1 = reads_files[0]
 		File? check_this_fastq_2 = reads_files[1]

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -217,7 +217,7 @@ task combined_decontamination_single {
 		File? decontaminated_fastq_2 = reads_out_base + ".decontam_2.fq.gz"
 		File? check_this_samples_fastqs = reads_out_base + "this_is_a_bad_sign"
 		File? check_this_fastq_1 = reads_files[0]
-		File? check_this_fastq_2 = reads_files[1]
+		#File? check_this_fastq_2 = reads_files[1]
 	}
 }
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -261,7 +261,7 @@ task combined_decontamination_multiple {
 	do
 		basename_ball=$(basename $BALL .tar)
 		sample_name="${basename_ball%%_*}"
-		echo "$sample_name\n" >> list_of_samples.txt
+		printf "%s\n" "$sample_name" >> list_of_samples.txt
 	done
 	sort list_of_samples.txt | uniq -d >> dupe_samples.txt
 
@@ -283,7 +283,7 @@ task combined_decontamination_multiple {
 
 		# mv read files into workdir and untar them
 		mv $BALL .
-		tar -xvf $basename_ball.tar
+		tar -xvf "$basename_ball.tar"
 
 		# the docker image uses bash v5 so we can use readarray to make an array easily
 		declare -a read_files
@@ -291,7 +291,7 @@ task combined_decontamination_multiple {
 
 		# map the reads
 		outfile_sam="$sample_name.sam"
-		clockwork map_reads ~{arg_unsorted_sam} ~{arg_threads} $sample_name ~{arg_ref_fasta} $outfile_sam "${read_files[@]}"
+		clockwork map_reads "~{arg_unsorted_sam}" ~{arg_threads} "$sample_name" ~{arg_ref_fasta} "$outfile_sam" "${read_files[@]}"
 		echo "Mapped $sample_name to decontamination reference."
 
 		if [[ "~{verbose}" = "true" ]]
@@ -322,13 +322,13 @@ task combined_decontamination_multiple {
 			~{arg_no_match_out_1} ~{arg_no_match_out_2} ~{arg_contam_out_1} ~{arg_contam_out_2} ~{arg_done_file}
 
 		# tar outputs because Cromwell still can't handle nested arrays nor structs properly
-		mkdir $sample_name
+		mkdir "$sample_name"
 		#mv "*.sam" /$sample_name
 		#mv "*counts.tsv" /$sample_name
-		mv $arg_reads_out1 ./$sample_name
-		mv $arg_reads_out2 ./$sample_name
-		tar -cf $sample_name.tar $sample_name
-		rm -rf ./$sample_name
+		mv "$arg_reads_out1" "./$sample_name"
+		mv "$arg_reads_out2" "./$sample_name"
+		tar -cf "$sample_name.tar" "$sample_name"
+		rm -rf "./${sample_name:?}"
 		rm "${read_files[@]}" # if this isn't done, the next iteration will grab the wrong reads
 		echo "Decontaminated $sample_name successfully."
 	done

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -191,6 +191,12 @@ task combined_decontamination_single {
 		fi
 	fi
 
+	# everything worked! let's delete the not-decontaminated fastqs we don't need
+	for inputfq in "${READS_FILES[@]}"
+	do
+		rm inputfq
+	done
+
 	echo "Decontamination completed."
 	echo "*********************************************************************"
 	>>>
@@ -206,10 +212,12 @@ task combined_decontamination_single {
 	output {
 		#File? mapped_to_decontam = glob("*.sam")[0]
 		File? counts_out_tsv = reads_out_base + "decontam.counts.tsv"
-		String? sample_name = read_string("sample_name.txt")
+		String sample_name = read_string("sample_name.txt")
 		File? decontaminated_fastq_1 = reads_out_base + "decontam_1.fq.gz"
 		File? decontaminated_fastq_2 = reads_out_base + "*decontam_2.fq.gz"
 		File? check_this_samples_fastqs = reads_out_base + "this_is_a_bad_sign"
+		File? check_this_fastq_1 = reads_files[0]
+		File? check_this_fastq_2 = reads_files[1]
 	}
 }
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -194,7 +194,7 @@ task combined_decontamination_single {
 	# everything worked! let's delete the not-decontaminated fastqs we don't need
 	for inputfq in "${READS_FILES[@]}"
 	do
-		rm inputfq
+		rm "$inputfq"
 	done
 
 	echo "Decontamination completed."

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -119,7 +119,7 @@ task combined_decontamination_single {
 	tar -xvf ~{basestem_reference}.tar
 
 	# map reads for decontamination
-	clockwork map_reads \
+	timeout -v --kill-after=45m 20m clockwork map_reads \
 		~{arg_unsorted_sam} \
 		~{arg_threads} \
 		$sample_name \
@@ -149,7 +149,7 @@ task combined_decontamination_single {
 	# this doesn't seem to be in the nextflow version of this pipeline, but it seems necessary
 	samtools sort -n $outfile_sam > sorted_by_read_name_$sample_name.sam
 
-	clockwork remove_contam \
+	timeout -v --kill-after=45m 20m clockwork remove_contam \
 		~{arg_metadata_tsv} \
 		sorted_by_read_name_$sample_name.sam \
 		$arg_counts_out \

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -39,6 +39,7 @@ task combined_decontamination_single {
 
 	# calculate stuff for the map_reads call
 	String read_file_basename = basename(reads_files[0]) # used to calculate sample name + outfile_sam
+	String reads_out_base = sub(read_file_basename, "_\d", "")
 	String basestem_reference = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{ref_fasta_filename}"
@@ -140,7 +141,7 @@ task combined_decontamination_single {
 			# no output, but don't break the whole pipeline
 			echo "clockwork map_reads killed."
 			echo "Consider checking $sample_name's fastq files."
-			touch "~{read_file_basename}.this_is_a_bad_sign"
+			touch "~{reads_out_base}.this_is_a_bad_sign"
 			exit 0
 		fi
 	fi
@@ -153,11 +154,11 @@ task combined_decontamination_single {
 	then
 		arg_counts_out="~{counts_out}"
 	else
-		arg_counts_out="~{read_file_basename}.decontam.counts.tsv"
+		arg_counts_out="~{reads_out_base}.decontam.counts.tsv"
 	fi
 
-	arg_reads_out1="~{read_file_basename}.decontam_1.fq.gz"
-	arg_reads_out2="~{read_file_basename}.decontam_2.fq.gz"
+	arg_reads_out1="~{reads_out_base}.decontam_1.fq.gz"
+	arg_reads_out2="~{reads_out_base}.decontam_2.fq.gz"
 
 	# this doesn't seem to be in the nextflow version of this pipeline, but it seems necessary
 	samtools sort -n $outfile_sam > sorted_by_read_name_$sample_name.sam
@@ -204,11 +205,11 @@ task combined_decontamination_single {
 
 	output {
 		#File? mapped_to_decontam = glob("*.sam")[0]
-		File? counts_out_tsv = read_file_basename + "decontam.counts.tsv"
+		File? counts_out_tsv = reads_out_base + "decontam.counts.tsv"
 		String? sample_name = read_string("sample_name.txt")
-		File? decontaminated_fastq_1 = read_file_basename + "decontam_1.fq.gz"
-		File? decontaminated_fastq_2 = read_file_basename + "*decontam_2.fq.gz"
-		File? check_this_samples_fastqs = read_file_basename + "this_is_a_bad_sign"
+		File? decontaminated_fastq_1 = reads_out_base + "decontam_1.fq.gz"
+		File? decontaminated_fastq_2 = reads_out_base + "*decontam_2.fq.gz"
+		File? check_this_samples_fastqs = reads_out_base + "this_is_a_bad_sign"
 	}
 }
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -140,7 +140,7 @@ task combined_decontamination_single {
 			# no output, but don't break the whole pipeline
 			echo "clockwork map_reads killed."
 			echo "Consider checking $sample_name's fastq files."
-			touch "$sample_name.this_is_a_bad_sign"
+			touch "~{read_file_basename}.this_is_a_bad_sign"
 			exit 0
 		fi
 	fi
@@ -153,11 +153,11 @@ task combined_decontamination_single {
 	then
 		arg_counts_out="~{counts_out}"
 	else
-		arg_counts_out="$sample_name.decontam.counts.tsv"
+		arg_counts_out="~{read_file_basename}.decontam.counts.tsv"
 	fi
 
-	arg_reads_out1="$sample_name.decontam_1.fq.gz"
-	arg_reads_out2="$sample_name.decontam_2.fq.gz"
+	arg_reads_out1="~{read_file_basename}.decontam_1.fq.gz"
+	arg_reads_out2="~{read_file_basename}.decontam_2.fq.gz"
 
 	# this doesn't seem to be in the nextflow version of this pipeline, but it seems necessary
 	samtools sort -n $outfile_sam > sorted_by_read_name_$sample_name.sam
@@ -185,7 +185,7 @@ task combined_decontamination_single {
 			# no output, but don't break the whole pipeline
 			echo "clockwork remove_contam killed."
 			echo "Consider checking $sample_name's fastq files."
-			touch "$sample_name.this_is_a_bad_sign"
+			touch "~{read_file_basename}.this_is_a_bad_sign"
 			exit 0
 		fi
 	fi
@@ -203,12 +203,12 @@ task combined_decontamination_single {
 	}
 
 	output {
-		File? mapped_to_decontam = glob("*.sam")[0]
-		File? counts_out_tsv = glob("*counts.tsv")[0]
+		#File? mapped_to_decontam = glob("*.sam")[0]
+		File? counts_out_tsv = read_file_basename + "decontam.counts.tsv"
 		String? sample_name = read_string("sample_name.txt")
-		File? decontaminated_fastq_1 = glob("*decontam_1.fq.gz")[0]
-		File? decontaminated_fastq_2 = glob("*decontam_2.fq.gz")[0]
-		File? check_this_samples_fastqs = glob("*.this_is_a_bad_sign")[0]
+		File? decontaminated_fastq_1 = read_file_basename + "decontam_1.fq.gz"
+		File? decontaminated_fastq_2 = read_file_basename + "*decontam_2.fq.gz"
+		File? check_this_samples_fastqs = read_file_basename + "this_is_a_bad_sign"
 	}
 }
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -39,7 +39,8 @@ task combined_decontamination_single {
 
 	# calculate stuff for the map_reads call
 	String read_file_basename = basename(reads_files[0]) # used to calculate sample name + outfile_sam
-	String reads_out_base = sub(read_file_basename, "_\d.fastq", "")
+	String read_file_basename2 = sub(read_file_basename, "_\d", "")
+	String read_file_basename3 = sub(read_file_basename2, ".fastq", "")
 	String basestem_reference = sub(basename(tarball_ref_fasta_and_index), "\.tar(?!.{5,})", "")  # TODO: double check the regex
 	String arg_unsorted_sam = if unsorted_sam == true then "--unsorted_sam" else ""
 	String arg_ref_fasta = "~{basestem_reference}/~{ref_fasta_filename}"
@@ -141,7 +142,7 @@ task combined_decontamination_single {
 			# no output, but don't break the whole pipeline
 			echo "clockwork map_reads killed."
 			echo "Consider checking $sample_name's fastq files."
-			touch "~{reads_out_base}.this_is_a_bad_sign"
+			touch "~{read_file_basename3}.this_is_a_bad_sign"
 			exit 0
 		fi
 	fi
@@ -154,11 +155,11 @@ task combined_decontamination_single {
 	then
 		arg_counts_out="~{counts_out}"
 	else
-		arg_counts_out="~{reads_out_base}.decontam.counts.tsv"
+		arg_counts_out="~{read_file_basename3}.decontam.counts.tsv"
 	fi
 
-	arg_reads_out1="~{reads_out_base}.decontam_1.fq.gz"
-	arg_reads_out2="~{reads_out_base}.decontam_2.fq.gz"
+	arg_reads_out1="~{read_file_basename3}.decontam_1.fq.gz"
+	arg_reads_out2="~{read_file_basename3}.decontam_2.fq.gz"
 
 	# this doesn't seem to be in the nextflow version of this pipeline, but it seems necessary
 	samtools sort -n $outfile_sam > sorted_by_read_name_$sample_name.sam
@@ -211,11 +212,11 @@ task combined_decontamination_single {
 
 	output {
 		#File? mapped_to_decontam = glob("*.sam")[0]
-		File? counts_out_tsv = reads_out_base + ".decontam.counts.tsv"
+		File? counts_out_tsv = read_file_basename3 + ".decontam.counts.tsv"
 		String sample_name = read_string("sample_name.txt")
-		File? decontaminated_fastq_1 = reads_out_base + ".decontam_1.fq.gz"
-		File? decontaminated_fastq_2 = reads_out_base + ".decontam_2.fq.gz"
-		File? check_this_samples_fastqs = reads_out_base + "this_is_a_bad_sign"
+		File? decontaminated_fastq_1 = read_file_basename3 + ".decontam_1.fq.gz"
+		File? decontaminated_fastq_2 = read_file_basename3 + ".decontam_2.fq.gz"
+		File? check_this_samples_fastqs = read_file_basename3 + "this_is_a_bad_sign"
 		File? check_this_fastq_1 = reads_files[0]
 		#File? check_this_fastq_2 = reads_files[1]
 	}

--- a/tasks/rm_contam.wdl
+++ b/tasks/rm_contam.wdl
@@ -9,7 +9,7 @@ task remove_contam {
 
 		# [supported] ...or you can pass in the zipped prepared reference plus the name of the TSV file
 		File?   tarball_metadata_tsv
-		String? filename_metadata_tsv = "remove_contam_metadata.tsv"
+		String filename_metadata_tsv = "remove_contam_metadata.tsv"
 
 		# these three are required in the original pipeline, but we can calculate them ourselves
 		String? counts_out


### PR DESCRIPTION
## Important changes
* combined_decontamination's output is now considered optional (and no longer relies on glob())
* combined_decontamination no longer sets pipefail -- if an unhandled error occurs, things might break badly -- need to test with those weird samples known to be iffy with variant calling!
* combined_decontamination's outputs have read names, not just sample names -- this could be regex'd away
* combined_decontamination no longer outputs mapped_to_decontam, because we really don't need that file