### PR TITLE
Rename some variables, adjust shellcheck

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -15,7 +15,7 @@ task combined_decontamination_single {
 		String      filename_metadata_tsv = "remove_contam_metadata.tsv"
 
 		# bonus options
-		Boolean     fail_on_timeout = false
+		Boolean     crash_on_timeout = false
 		Int         subsample_cutoff = -1
 		Int         subsample_seed = 1965
 		Int?        threads
@@ -45,7 +45,7 @@ task combined_decontamination_single {
 		reads_files: "FASTQs to decontaminate"
 		filename_metadata_tsv: "Name of the metadata tsv within tarball_ref_fasta_and_index"
 		
-		fail_on_timeout: "If true, fail entire pipeline if a task times out (see timeout_minutes)"
+		crash_on_timeout: "If true, fail entire pipeline if a task times out (see timeout_minutes)"
 		subsample_cutoff: "If a FASTQ is larger than this size in megabytes, subsample 1,000,000 random reads and use that instead (-1 to disable)"
 		subsample_seed: "Seed to use when subsampling (default: year UCSC was founded)"
 		threads: "Attempt to use these many threads when mapping reads"
@@ -156,7 +156,7 @@ task combined_decontamination_single {
 	if [[ $exit = 124 ]]
 	then
 		echo "ERROR -- clockwork map_reads timed out"
-		if [[ "~{fail_on_timeout}" = "true" ]]
+		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
 			set -eux -o pipefail
 			exit 1
@@ -166,7 +166,7 @@ task combined_decontamination_single {
 	elif [[ $exit = 137 ]]
 	then
 		echo "ERROR -- clockwork map_reads was killed -- it may have run out of memory"
-		if [[ "~{fail_on_timeout}" = "true" ]]
+		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
 			set -eux -o pipefail
 			exit 1
@@ -218,7 +218,7 @@ task combined_decontamination_single {
 	if [[ $exit = 124 ]]
 	then
 		echo "ERROR -- clockwork remove_contam timed out"
-		if [[ "~{fail_on_timeout}" = "true" ]]
+		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
 			set -eux -o pipefail
 			exit 1
@@ -228,7 +228,7 @@ task combined_decontamination_single {
 	elif [[ $exit = 137 ]]
 	then
 		echo "ERROR -- clockwork remove_contam was killed -- it may have run out of memory"
-		if [[ "~{fail_on_timeout}" = "true" ]]
+		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
 			set -eux -o pipefail
 			exit 1

--- a/tasks/ref_prep.wdl
+++ b/tasks/ref_prep.wdl
@@ -53,9 +53,9 @@ task reference_prepare {
 	# excessive usage of select_first() is required due to basename() and sub() not working on optional types, even if setting an optional variable
 	String is_there_any_tsv = select_first([contam_tsv_in_reference_folder, contam_tsv, "false"])
 	String basestem_reference = sub(basename(select_first([reference_folder, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
-	String? intermed_tsv1 = if defined(contam_tsv_in_reference_folder) then "~{basestem_reference}/~{contam_tsv_in_reference_folder}" else ""
-	String? intermed_tsv2 = if defined(contam_tsv) then "~{contam_tsv}" else ""
-	String? arg_tsv       = if is_there_any_tsv == "false" then "" else "--contam_tsv ~{intermed_tsv1}~{intermed_tsv2}"
+	String intermed_tsv1 = if defined(contam_tsv_in_reference_folder) then "~{basestem_reference}/~{contam_tsv_in_reference_folder}" else ""
+	String intermed_tsv2 = if defined(contam_tsv) then "~{contam_tsv}" else ""
+	String arg_tsv       = if is_there_any_tsv == "false" then "" else "--contam_tsv ~{intermed_tsv1}~{intermed_tsv2}"
 	
 	# calculate the remaining arguments
 	String arg_ref               = if defined(fasta_file) then "~{fasta_file}" else "~{basestem_reference}/~{reference_fa_string}"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -139,8 +139,8 @@ task variant_call_one_sample_simple {
 		echo "This sample threw a warning during cortex's clean binaries step."
 		echo "This likely means it's too small for variant calling."
 		echo "Expect this task to have errored at minos adjudicate."
-		size_of_read1=$(ls -lh var_call_"~{sample_name}"/trimmed_reads.0.1.fq.gz | awk '{print $5}')
-		echo "Read 1 is $size_of_read1"
+		size_of_read1=$(stat -c %s var_call_"~{sample_name}"/trimmed_reads.0.1.fq.gz)
+		echo "Read 1 is $size_of_read1 bytes"
 		#echo Read 2 is "$(ls -lh var_call_~{sample_name}/trimmed_reads.0.2.fq.gz | awk '{print $5}')"
 		#gunzip -dk "var_call_~{sample_name}/trimmed_reads.0.2.fq.gz"
 		#size_of_decompressed_read_2=$(ls -lh var_call_"~{sample_name}"/trimmed_reads.0.2.fq | awk '{print $5}')
@@ -204,7 +204,7 @@ task variant_call_one_sample_verbose {
 	# estimate disk size required
 	Int size_in = ceil(size(select_first([reads_files, tarball_of_reads_files]), "GB"))
 	Int finalDiskSize = ceil(2*size_in + addldisk)
-	String basestem_ref_dir = sub(basename(select_first([ref_dir, "bogus fallback value"])), "\.tar(?!.{5,})", "") # TODO: double check the regex
+	String basestem_ref_dir = sub((basename(ref_dir)), "\.tar(?!.{5,})", "") # TODO: clean up the regex
 	
 	# generate command line arguments
 	String arg_debug = if(debug) then "--debug" else ""
@@ -277,8 +277,9 @@ task variant_call_one_sample_verbose {
 	if [[ $CORTEX_WARNING == WARNING* ]] ;
 	then
 		echo "***********"
-		echo "This sample threw a warning during cortex's clean binaries step. This likely means it's too small for variant calling. Expect this task to have errored at minos adjudicate."
-		size_of_read1=$(ls -lh var_call_"$sample_name"/trimmed_reads.0.1.fq.gz | awk '{print $5}')
+		echo "This sample threw a warning during cortex's clean binaries step. This likely means it's too small for variant calling, but not small enough to fail minimap2."
+		echo "Expect this task to have errored at minos adjudicate."
+		size_of_read1=$(stat -c %s var_call_"~{sample_name}"/trimmed_reads.0.1.fq.gz)
 		echo "Read 1 is $size_of_read1"
 		#echo "Read 2 is $(ls -lh var_call_$sample_name/trimmed_reads.0.2.fq.gz | awk '{print $5}')"
 		#gunzip -dk var_call_$sample_name/trimmed_reads.0.2.fq.gz


### PR DESCRIPTION
* fail_on_timeout --> crash_on_timeout
* don't allow user to set `force` because it is meaningless in a WDL context
* use stat instead of ls to determine filesize when cortex throws a warning
* some shellcheck fixes that were bothering me 