### PR TITLE
Ignore bad samples

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -143,7 +143,7 @@ task combined_decontamination_single {
 	# is wonky on some backends (understandably!)
 	for inputfq in "${READS_FILES[@]}"
 	do
-		cp "$inputfq" "~{read_file_basename}_wonky.fastq"
+		cp "$inputfq" "~{read_file_basename}_dcntmfail.fastq"
 	done
 
 	# map reads for decontamination
@@ -251,7 +251,7 @@ task combined_decontamination_single {
 		exit 1
 	fi
 
-	rm "~{read_file_basename}_wonky.fastq"
+	rm "~{read_file_basename}_dcntmfail.fastq"
 
 	echo "Decontamination completed."
 
@@ -271,7 +271,7 @@ task combined_decontamination_single {
 		File? counts_out_tsv = sample_name + ".decontam.counts.tsv"
 		File? decontaminated_fastq_1 = sample_name + "_1.decontam.fq.gz"
 		File? decontaminated_fastq_2 = sample_name + "_2.decontam.fq.gz"
-		File? check_this_fastq = read_file_basename + "_wonky.fastq"
+		File? check_this_fastq = read_file_basename + "_dcntmfail.fastq"
 	}
 }
 

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -15,7 +15,7 @@ task variant_call_one_sample_simple {
 		Array[File] reads_files
 
 		# optional args
-		Boolean debug            = true
+		Boolean debug            = false
 		Boolean crash_on_error   = false
 		Boolean crash_on_timeout = false
 		Int? mem_height
@@ -73,7 +73,7 @@ task variant_call_one_sample_simple {
 
 	if [[ "~{debug}" = "true" ]]
 	then
-		ls -R * > contents_1.txt
+		ls -R ./* > contents_1.txt
 		for inputfq in "${READS_FILES[@]}"
 		do
 			cp "$inputfq" "~{sample_name}_varclfail.fastq"
@@ -136,7 +136,7 @@ task variant_call_one_sample_simple {
 	
 	if [[ "~{debug}" = "true" ]]
 	then
-		ls -R * > contents_2.txt
+		ls -R ./* > contents_2.txt
 		echo mving VCFs from var_call_"~{sample_name}"/*.vcf to ./"~{sample_name}"*.vcf
 	fi
 
@@ -147,33 +147,12 @@ task variant_call_one_sample_simple {
 	# rename the bam file
 	mv var_call_"~{sample_name}"/map.bam ./"~{sample_name}"_to_~{basestem_ref_dir}.bam
 
-	# debugging stuff
-	CORTEX_WARNING=$(head -22 var_call_"~{sample_name}"/cortex/cortex.log | tail -1)
-	if [[ $CORTEX_WARNING == WARNING* ]] ;
-	then
-		echo "***********"
-		echo "This sample threw a warning during cortex's clean binaries step."
-		echo "This likely means it's too small for variant calling."
-		echo "Expect this task to have errored at minos adjudicate."
-		size_of_read1=$(stat -c %s var_call_"~{sample_name}"/trimmed_reads.0.1.fq.gz)
-		echo "Read 1 is $size_of_read1 bytes"
-		#echo Read 2 is "$(ls -lh var_call_~{sample_name}/trimmed_reads.0.2.fq.gz | awk '{print $5}')"
-		#gunzip -dk "var_call_~{sample_name}/trimmed_reads.0.2.fq.gz"
-		#size_of_decompressed_read_2=$(ls -lh var_call_"~{sample_name}"/trimmed_reads.0.2.fq | awk '{print $5}')
-		#echo "Decompressed read 2 is $size_of_decompressed_read_2"
-		echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
-		head -50 "var_call_~{sample_name}/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf"
-		exit 0
-	else
-		echo "This sample likely didn't throw a warning during cortex's clean binaries step."
-	fi
-
 	if [[ "~{debug}" = "true" ]]
 	then
-		ls -R * > contents_3.txt
+		ls -R ./* > contents_3.txt
+		tar -c "var_call_~{sample_name}/" > "~{sample_name}.tar"
+		rm "~{sample_name}_varclfail.fastq"
 	fi
-
-	rm "~{read_file_basename}_varclfail.fastq"
 
 	echo "Variant calling completed."
 	>>>
@@ -188,14 +167,17 @@ task variant_call_one_sample_simple {
 	}
 
 	output {
-		File mapped_to_ref = glob("*~{basestem_ref_dir}.bam")[0]
+		# the outputs you care about
+		File? mapped_to_ref = sample_name+"_to_"+basestem_ref_dir+".bam"
 		File? vcf_final_call_set = sample_name+".vcf"
-		#File vcf_cortex = glob("*_cortex.vcf")[0]
-		#File vcf_samtools = glob("*_samtools.vcf")[0]
+
+		# debugging stuff
 		File? bad_fastq = sample_name+"_varclfail.fastq"
-		File? workdir1 = "contents_1.txt"
-		File? workdir2 = "contents_2.txt"
-		File? workdir3 = "contents_3.txt"
+		File? cortex_log = "var_call_"+sample_name+"/cortex/cortex.log"
+		File? ls1 = "contents_1.txt"
+		File? ls2 = "contents_2.txt"
+		File? ls3 = "contents_3.txt"
+		File? workdir_tarball = sample_name+".tar"
 	}
 }
 
@@ -278,7 +260,7 @@ task variant_call_one_sample_verbose {
 	if clockwork variant_call_one_sample \
 		--sample_name "$sample_name" ~{arg_debug} ~{arg_mem_height} ~{arg_keep_bam} ~{arg_force} \
 		~{basestem_ref_dir} "$arg_outdir" \
-		${read_files_array[@]}; then echo "Task completed successfully (probably)"
+		"${read_files_array[@]}"; then echo "Task completed successfully (probably)"
 	else
 		echo "Caught an error."
 		touch "$sample_name"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -15,7 +15,7 @@ task variant_call_one_sample_simple {
 		Array[File] reads_files
 
 		# optional args
-		Boolean debug            = false
+		Boolean debug            = true
 		Boolean crash_on_error   = false
 		Boolean crash_on_timeout = false
 		Int? mem_height
@@ -73,19 +73,12 @@ task variant_call_one_sample_simple {
 
 	if [[ "~{debug}" = "true" ]]
 	then
-		apt-get install -y tree
-		tree > tree1.txt
+		ls -R * > contents_1.txt
+		for inputfq in "${READS_FILES[@]}"
+		do
+			cp "$inputfq" "~{sample_name}_wonky.fastq"
+		done
 	fi
-
-	# this keeps track of outputs to fastqc
-	# this will be deleted if we var call successfully
-	# we use copies of the inputs because this is easier
-	# than trying to glob, and because deleting inputs
-	# is wonky on some backends (understandably!)
-	for inputfq in "${READS_FILES[@]}"
-	do
-		cp "$inputfq" "~{read_file_basename}_wonky.fastq"
-	done
 
 	timeout -v ~{timeout}m clockwork variant_call_one_sample \
 	--sample_name "~{sample_name}" \
@@ -185,9 +178,9 @@ task variant_call_one_sample_simple {
 		File? vcf_final_call_set = sample_name+".vcf"
 		#File vcf_cortex = glob("*_cortex.vcf")[0]
 		#File vcf_samtools = glob("*_samtools.vcf")[0]
-		File? debugtree1 = "tree1.txt"
-		File? debugtree2 = "tree2.txt"
-		File? debugtree3 = "tree3.txt"
+		File? workdir1 = "contents_1.txt"
+		File? workdir2 = "contents_2.txt"
+		File? workdir3 = "contents_3.txt"
 	}
 }
 

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -16,6 +16,7 @@ task variant_call_one_sample_simple {
 
 		# optional args
 		Boolean debug            = false
+		Boolean crash_on_error   = false
 		Boolean crash_on_timeout = false
 		Int? mem_height
 		Int timeout = 120
@@ -76,6 +77,16 @@ task variant_call_one_sample_simple {
 		tree > tree1.txt
 	fi
 
+	# this keeps track of outputs to fastqc
+	# this will be deleted if we var call successfully
+	# we use copies of the inputs because this is easier
+	# than trying to glob, and because deleting inputs
+	# is wonky on some backends (understandably!)
+	for inputfq in "${READS_FILES[@]}"
+	do
+		cp "$inputfq" "~{read_file_basename}_wonky.fastq"
+	done
+
 	timeout -v ~{timeout}m clockwork variant_call_one_sample \
 	--sample_name "~{sample_name}" \
 	~{arg_debug} \
@@ -115,7 +126,7 @@ task variant_call_one_sample_simple {
 		set -eux -o pipefail
 		exit 1
 	else
-		echo "ERROR -- clockwork variant_call_one_sample returned $exit for unknwon reasons"
+		echo "ERROR -- clockwork variant_call_one_sample returned $exit for unknown reasons"
 		set -eux -o pipefail
 		exit 1
 	fi

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -76,7 +76,7 @@ task variant_call_one_sample_simple {
 		ls -R * > contents_1.txt
 		for inputfq in "${READS_FILES[@]}"
 		do
-			cp "$inputfq" "~{sample_name}_wonky.fastq"
+			cp "$inputfq" "~{sample_name}_varclfail.fastq"
 		done
 	fi
 
@@ -126,7 +126,7 @@ task variant_call_one_sample_simple {
 	
 	if [[ "~{debug}" = "true" ]]
 	then
-		tree > tree2.txt
+		ls -R * > contents_2.txt
 		echo mving VCFs from var_call_"~{sample_name}"/*.vcf to ./"~{sample_name}"*.vcf
 	fi
 
@@ -160,8 +160,12 @@ task variant_call_one_sample_simple {
 
 	if [[ "~{debug}" = "true" ]]
 	then
-		tree > tree3.txt
+		ls -R * > contents_3.txt
 	fi
+
+	rm "~{read_file_basename}_varclfail.fastq"
+
+	echo "Variant calling completed."
 	>>>
 
 	runtime {
@@ -178,6 +182,7 @@ task variant_call_one_sample_simple {
 		File? vcf_final_call_set = sample_name+".vcf"
 		#File vcf_cortex = glob("*_cortex.vcf")[0]
 		#File vcf_samtools = glob("*_samtools.vcf")[0]
+		File? bad_fastq = sample_name+"_varclfail.fastq"
 		File? workdir1 = "contents_1.txt"
 		File? workdir2 = "contents_2.txt"
 		File? workdir3 = "contents_3.txt"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -116,12 +116,22 @@ task variant_call_one_sample_simple {
 	elif [[ $exit = 1 ]]
 	then
 		echo "ERROR -- clockwork variant_call_one_sample errored out for unknown reasons"
-		set -eux -o pipefail
-		exit 1
+		if [[ "~{crash_on_error}" = "true" ]]
+		then
+			set -eux -o pipefail
+			exit 1
+		else
+			exit 0
+		fi
 	else
 		echo "ERROR -- clockwork variant_call_one_sample returned $exit for unknown reasons"
-		set -eux -o pipefail
-		exit 1
+		if [[ "~{crash_on_error}" = "true" ]]
+		then
+			set -eux -o pipefail
+			exit 1
+		else
+			exit 0
+		fi
 	fi
 	
 	if [[ "~{debug}" = "true" ]]
@@ -134,7 +144,7 @@ task variant_call_one_sample_simple {
 	mv var_call_"~{sample_name}"/cortex.vcf ./"~{sample_name}"_cortex.vcf
 	mv var_call_"~{sample_name}"/samtools.vcf ./"~{sample_name}"_samtools.vcf
 
-	# rename the bam file to the basestem
+	# rename the bam file
 	mv var_call_"~{sample_name}"/map.bam ./"~{sample_name}"_to_~{basestem_ref_dir}.bam
 
 	# debugging stuff


### PR DESCRIPTION
* Better debugging in variant calling
* Bad samples that break the variant caller can be dropped and ignored, just like how timing out is handled
* "wonky" fastqs have a better filename now
* Don't apt-get install tree!
* If debugging is true, output workdir
* Get rid of the buggy and rarely helpful CORTEX WARNING redirect
* Shellcheck fixes, because I can't help myself