### PR TITLE
Refprep improvements

### DIFF
--- a/tasks/ref_prep.wdl
+++ b/tasks/ref_prep.wdl
@@ -62,9 +62,6 @@ task reference_prepare_myco {
 		rm ~{basestem_reference}.tar
 
 		clockwork reference_prepare --outdir ~{outdir} ~{arg_ref} ~{arg_cortex_mem_height} ~{arg_tsv}
-		ls -lha
-		ls -lha ~{basestem_reference}
-		ls -lha ~{outdir}
 		tar -c ~{outdir}/ > ~{outdir}.tar
 
 	>>>
@@ -78,7 +75,7 @@ task reference_prepare_myco {
 		preemptible: "${preempt}"
 	}
 	output {
-		File? H37Rv_for_later = "~{basestem_reference}/ref.fa"
+		File? H37Rv_for_later = "~{outdir}/ref.fa"
 		File? remove_contam_tsv = "remove_contam_metadata.tsv"
 		File  tar_ref_prepd = glob("*.tar")[0]
 

--- a/tasks/ref_prep.wdl
+++ b/tasks/ref_prep.wdl
@@ -62,6 +62,9 @@ task reference_prepare_myco {
 		rm ~{basestem_reference}.tar
 
 		clockwork reference_prepare --outdir ~{outdir} ~{arg_ref} ~{arg_cortex_mem_height} ~{arg_tsv}
+		ls -lha
+		ls -lha ~{basestem_reference}
+		ls -lha ~{outdir}
 		tar -c ~{outdir}/ > ~{outdir}.tar
 
 	>>>

--- a/workflows/refprep-TB.wdl
+++ b/workflows/refprep-TB.wdl
@@ -1,9 +1,6 @@
 version 1.0
-#import "./tasks/ref_prep.wdl"
-#import "./tasks/dl_TB_ref.wdl" as dl_TB_ref
-
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/ref_prep.wdl"
-import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/main/tasks/dl_TB_ref.wdl" as dl_TB_ref
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/refprep-improvements/tasks/ref_prep.wdl"
+import "https://raw.githubusercontent.com/aofarrel/clockwork-wdl/refprep-improvements/tasks/dl_TB_ref.wdl" as dl_TB_ref
 
 # correspond with https://github.com/iqbal-lab-org/clockwork/wiki/Walkthrough-scripts-only#get-and-index-reference-genomes
 
@@ -20,11 +17,17 @@ workflow ClockworkRefPrepTB {
 		# Define this input to skip indexing the decontamination reference.
 		File?   bluepeter__tar_indexd_dcontm_ref
 		#
-		# Define this input to skip index_H37v_reference.
-		File?   bluepeter__tar_indexd_H37Rv_ref
-		#
-		# If you define all three of these, this workflow basically does nothing and
-		# will pass you inputs as outputs.
+		# As of version 4.1.0 of clockwork-wdl I no longer allow users to skip H37Rv 
+		# indexing by defining bluepeter__tar_indexd_H37Rv_ref. Nope. Not allowed.
+		# Nowadays, that indexing step also creates the reference genome used by
+		# myco's later steps (tbprofiler and phylogenetic tree stuff), in order to
+		# stop users from having to upload two more copies of the TB genome for myco's
+		# later tasks. Thusly, it just isn't a good idea to let people skip the 
+		# (most likely quickest) step of this workflow anymore. Sure, I could
+		# allow users to input that particular fa file, but because the tree steps
+		# require such a specific chromosome title that just happens to match what
+		# gets downloaded here, it's safer to just tell users to run this workflow once
+		# and then rely on call cacheing.
 	}
 
 	if (!defined(bluepeter__tar_tb_ref_raw)) {
@@ -39,13 +42,13 @@ workflow ClockworkRefPrepTB {
 	}
 
 	if (!defined(bluepeter__tar_indexd_dcontm_ref)) {
-		call ref_prep.reference_prepare as index_decontamination_ref {
+		call ref_prep.reference_prepare_myco as index_decontamination_ref {
 			input:
 				reference_folder = select_first([bluepeter__tar_tb_ref_raw,
 					download_tb_reference_files.tar_tb_ref_raw]),
-				reference_fa_string            = "remove_contam.fa.gz",
-				contam_tsv_in_reference_folder = "remove_contam.tsv",
-				outdir                         = "Ref.remove_contam"
+				reference_fa_string                        = "remove_contam.fa.gz",
+				filename_of_contam_tsv_in_reference_folder = "remove_contam.tsv",
+				outdir                                     = "Ref.remove_contam"
 		}
 
 		# Ref.remove_contam.tar
@@ -55,28 +58,28 @@ workflow ClockworkRefPrepTB {
 		#  └── remove_contam_metadata.tsv
 	}
 
-	if (!defined(bluepeter__tar_indexd_H37Rv_ref)) {
-		call ref_prep.reference_prepare as index_H37Rv_reference {
-			input:
-				reference_folder = select_first([bluepeter__tar_tb_ref_raw,
-					download_tb_reference_files.tar_tb_ref_raw]),
-				reference_fa_string = "NC_000962.3.fa",
-				outdir              = "Ref.H37Rv"
-		}
-
-		# Ref.H37Rv.tar
-		#  ├── ref.fa
-		#  ├── ref.fa.fai
-		#  ├── ref.fa.minimap2_idx
-		#  └── ref.k31.ctx
+	call ref_prep.reference_prepare_myco as index_H37Rv_reference {
+		input:
+			reference_folder = select_first([bluepeter__tar_tb_ref_raw,
+				download_tb_reference_files.tar_tb_ref_raw]),
+			reference_fa_string = "NC_000962.3.fa",
+			outdir              = "Ref.H37Rv"
 	}
 
+	# Ref.H37Rv.tar
+	#  ├── ref.fa
+	#  ├── ref.fa.fai
+	#  ├── ref.fa.minimap2_idx
+	#  └── ref.k31.ctx
+
 	output {
-		File   tar_indexd_dcontm_ref    = select_first([bluepeter__tar_indexd_dcontm_ref,
+		File  tar_indexd_dcontm_ref    = select_first([bluepeter__tar_indexd_dcontm_ref,
 														index_decontamination_ref.tar_ref_prepd])
 		
-		File   tar_indexd_H37Rv_ref     = select_first([bluepeter__tar_indexd_H37Rv_ref,
-														index_H37Rv_reference.tar_ref_prepd])
+		File  tar_indexd_H37Rv_ref     = select_first([index_H37Rv_reference.tar_ref_prepd])
+											 
+		File  reference_genome_fasta   = select_first([index_H37Rv_reference.H37Rv_for_later])
+
 	}
 
 	meta {


### PR DESCRIPTION
* There's now two refprep tasks, one that is myco focused and simple, and one that is a bit fancier
* Better debugging output
* The "real" TB reference is now a workflow level output, which stops us from having to input the reference genome twice when building trees (thrice if using tbprofiler without a custom docker image)