### PR TITLE
Add error/status codes to combo decontam task and main variant caller task

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -261,6 +261,7 @@ task combined_decontamination_single_ref_included {
 
 	# We passed, so delete the output that would signal to run fastqc
 	rm "~{read_file_basename}_dcntmfail.fastq"
+	echo "PASS" >> ERROR
 
 	echo "Decontamination completed."
 
@@ -285,7 +286,7 @@ task combined_decontamination_single_ref_included {
 		File? decontaminated_fastq_1 = sample_name + "_1.decontam.fq.gz"
 		File? decontaminated_fastq_2 = sample_name + "_2.decontam.fq.gz"
 		File? check_this_fastq = read_file_basename + "_dcntmfail.fastq"
-		String? decontam_error = read_string("ERROR")
+		String ERROR = read_string("ERROR")
 	}
 }
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -117,19 +117,6 @@ task combined_decontamination_single_ref_included {
 			fi
 		done
 	fi
-	
-	# REVERT ME
-	if (( $RANDOM > 25000 ))
-	then
-		echo "DECONTAMINATION_DEBUG_ERROR" >> ERROR
-		exit 0
-	else
-		echo "PASS" >> ERROR
-		touch "~{sample_name}_1.decontam.fq.gz"
-		touch "~{sample_name}_2.decontam.fq.gz"
-		exit 0
-	fi
-
 
 	# Terra-Cromwell does not place you in the home dir, but rather one folder down, so we have
 	# to go up one to get the ref genome. miniwdl goes further. Who knows what other executors do.

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -31,7 +31,7 @@ task combined_decontamination_single_ref_included {
 		# runtime attributes
 		Int addldisk = 100
 		Int cpu = 8
-		Int memory = 2
+		Int memory = 16
 		Int preempt = 1
 		Boolean ssd = true
 	}
@@ -117,6 +117,19 @@ task combined_decontamination_single_ref_included {
 			fi
 		done
 	fi
+	
+	# REVERT ME
+	if (( $RANDOM > 25000 ))
+	then
+		echo "DECONTAMINATION_DEBUG_ERROR" >> ERROR
+		exit 0
+	else
+		echo "PASS" >> ERROR
+		touch "~{sample_name}_1.decontam.fq.gz"
+		touch "~{sample_name}_2.decontam.fq.gz"
+		exit 0
+	fi
+
 
 	# Terra-Cromwell does not place you in the home dir, but rather one folder down, so we have
 	# to go up one to get the ref genome. miniwdl goes further. Who knows what other executors do.
@@ -286,7 +299,7 @@ task combined_decontamination_single_ref_included {
 		File? decontaminated_fastq_1 = sample_name + "_1.decontam.fq.gz"
 		File? decontaminated_fastq_2 = sample_name + "_2.decontam.fq.gz"
 		File? check_this_fastq = read_file_basename + "_dcntmfail.fastq"
-		String ERROR = read_string("ERROR")
+		String errorcode = read_string("ERROR")
 	}
 }
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -31,7 +31,7 @@ task combined_decontamination_single_ref_included {
 		# runtime attributes
 		Int addldisk = 100
 		Int cpu = 8
-		Int memory = 16
+		Int memory = 2
 		Int preempt = 1
 		Boolean ssd = true
 	}
@@ -148,9 +148,11 @@ task combined_decontamination_single_ref_included {
 		echo "ERROR -- clockwork map_reads timed out"
 		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
+			echo "DECONTAMINATION_MAP_READS_TIMEOUT" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 			set -eux -o pipefail
 			exit 1
 		else
+			echo "DECONTAMINATION_MAP_READS_TIMEOUT" >> ERROR
 			exit 0
 		fi
 	elif [[ $exit = 137 ]]
@@ -158,9 +160,11 @@ task combined_decontamination_single_ref_included {
 		echo "ERROR -- clockwork map_reads was killed -- it may have run out of memory"
 		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
+			echo "DECONTAMINATION_MAP_READS_KILLED" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 			set -eux -o pipefail
 			exit 1
 		else
+			echo "DECONTAMINATION_MAP_READS_KILLED" >> ERROR
 			exit 0
 		fi
 	elif [[ $exit = 0 ]]
@@ -169,10 +173,12 @@ task combined_decontamination_single_ref_included {
 	elif [[ $exit = 1 ]]
 	then
 		echo "ERROR -- clockwork map_reads errored out for unknown reasons"
+		echo "DECONTAMINATION_MAP_READS_UNKNOWN_ERROR" >> ERROR # since we exit 1 after this, this output may not be delocalized
 		set -eux -o pipefail
 		exit 1
 	else
 		echo "ERROR -- clockwork map_reads returned $exit for unknown reasons"
+		echo "DECONTAMINATION_MAP_READS_UNKNOWN_ERROR" >> ERROR # since we exit 1 after this, this output may not be delocalized
 		set -eux -o pipefail
 		exit 1
 	fi
@@ -218,9 +224,11 @@ task combined_decontamination_single_ref_included {
 		echo "ERROR -- clockwork remove_contam timed out"
 		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
+			echo "DECONTAMINATION_RM_CONTAM_TIMEOUT" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 			set -eux -o pipefail
 			exit 1
 		else
+			echo "DECONTAMINATION_RM_CONTAM_TIMEOUT" >> ERROR
 			exit 0
 		fi
 	elif [[ $exit = 137 ]]
@@ -228,9 +236,11 @@ task combined_decontamination_single_ref_included {
 		echo "ERROR -- clockwork remove_contam was killed -- it may have run out of memory"
 		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
+			echo "DECONTAMINATION_RM_CONTAM_KILLED" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 			set -eux -o pipefail
 			exit 1
 		else
+			echo "DECONTAMINATION_RM_CONTAM_KILLED" >> ERROR
 			exit 0
 		fi
 	elif [[ $exit = 0 ]]
@@ -239,10 +249,12 @@ task combined_decontamination_single_ref_included {
 	elif [[ $exit = 1 ]]
 	then
 		echo "ERROR -- clockwork remove_contam errored out for unknown reasons"
+		echo "DECONTAMINATION_RM_CONTAM_UNKNOWN_ERROR" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 		set -eux -o pipefail
 		exit 1
 	else
 		echo "ERROR -- clockwork remove_contam returned $exit for unknown reasons"
+		echo "DECONTAMINATION_RM_CONTAM_UNKNOWN_ERROR" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 		set -eux -o pipefail
 		exit 1
 	fi
@@ -273,6 +285,7 @@ task combined_decontamination_single_ref_included {
 		File? decontaminated_fastq_1 = sample_name + "_1.decontam.fq.gz"
 		File? decontaminated_fastq_2 = sample_name + "_2.decontam.fq.gz"
 		File? check_this_fastq = read_file_basename + "_dcntmfail.fastq"
+		String? decontam_error = read_string("ERROR")
 	}
 }
 

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -62,18 +62,6 @@ task variant_call_one_sample_ref_included {
 	}
 	
 	command <<<
-
-	# REVERT ME
-	if (( $RANDOM > 16383 ))
-	then
-		echo "VARIANT_CALLING_DEBUG_ERROR" >> ERROR
-		exit 0
-	else
-		echo "PASS" >> ERROR
-		exit 0
-	fi
-	
-	
 	
 	# Untar the reference (this will put it in the workdir) 
 	tar -xvf /ref/Ref.H37Rv.tar

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -62,6 +62,19 @@ task variant_call_one_sample_ref_included {
 	}
 	
 	command <<<
+
+	# REVERT ME
+	if (( $RANDOM > 16383 ))
+	then
+		echo "VARIANT_CALLING_DEBUG_ERROR" >> ERROR
+		exit 0
+	else
+		echo "PASS" >> ERROR
+		exit 0
+	fi
+	
+	
+	
 	# Untar the reference (this will put it in the workdir) 
 	tar -xvf /ref/Ref.H37Rv.tar
 
@@ -204,7 +217,7 @@ task variant_call_one_sample_ref_included {
 		# debugging stuff
 		File? check_this_fastq = sample_name+"_varclfail.fastq.gz"
 		File? cortex_log = "var_call_"+sample_name+"/cortex/cortex.log"
-		String ERROR = read_string("ERROR")
+		String errorcode = read_string("ERROR")
 		File? ls1 = "contents_1.txt"
 		File? ls2 = "contents_2.txt"
 		File? ls3 = "contents_3.txt"

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -157,7 +157,7 @@ task variant_call_one_sample_ref_included {
 			#gunzip -dk var_call_$sample_name/trimmed_reads.0.2.fq.gz
 			#echo "Decompressed read 2 is $(ls -lh var_call_$sample_name/trimmed_reads.0.2.fq | awk '{print $5}')"
 			echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
-			head -50 var_call_"$sample_name"/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
+			head -50 var_call_"~{sample_name}"/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
 			echo "***********"
 			echo "VARIANT_CALLING_ADJUDICATION_FAILURE"
 		else
@@ -184,7 +184,7 @@ task variant_call_one_sample_ref_included {
 		# check to see if the Cortex log has any information
 		# TODO: I don't remember if minos_adjudicate crashes due to small sample size have an rc of 1 or something else; ideally we'd only
 		# put this check in one place
-		CORTEX_WARNING=$(head -22 var_call_"$sample_name"/cortex/cortex.log | tail -1)
+		CORTEX_WARNING=$(head -22 var_call_"~{sample_name}"/cortex/cortex.log | tail -1)
 		if [[ $CORTEX_WARNING == WARNING* ]] ;
 		then
 			echo "***********"
@@ -196,7 +196,7 @@ task variant_call_one_sample_ref_included {
 			#gunzip -dk var_call_$sample_name/trimmed_reads.0.2.fq.gz
 			#echo "Decompressed read 2 is $(ls -lh var_call_$sample_name/trimmed_reads.0.2.fq | awk '{print $5}')"
 			echo "The first 50 lines of the Cortex VCF (if all you see are about 30 lines of headers, this is likely an empty VCF!):"
-			head -50 var_call_"$sample_name"/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
+			head -50 var_call_"~{sample_name}"/cortex/cortex.out/vcfs/cortex_wk_flow_I_RefCC_FINALcombined_BC_calls_at_all_k.decomp.vcf
 			echo "***********"
 			echo "VARIANT_CALLING_ADJUDICATION_FAILURE"
 		else

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -97,9 +97,11 @@ task variant_call_one_sample_ref_included {
 		fi
 		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
+			echo "VARIANT_CALLING_TIMEOUT" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 			set -eux -o pipefail
 			exit 1
 		else
+			echo "VARIANT_CALLING_TIMEOUT" >> ERROR 
 			exit 0
 		fi
 	elif [[ $exit = 137 ]]
@@ -111,9 +113,11 @@ task variant_call_one_sample_ref_included {
 		fi
 		if [[ "~{crash_on_timeout}" = "true" ]]
 		then
+			echo "VARIANT_CALLING_KILLED" >> ERROR  # since we exit 1 after this, this output may not be delocalized
 			set -eux -o pipefail
 			exit 1
 		else
+			echo "VARIANT_CALLING_KILLED" >> ERROR
 			exit 0
 		fi
 	elif [[ $exit = 0 ]]
@@ -176,7 +180,8 @@ task variant_call_one_sample_ref_included {
 		tar -c "var_call_~{sample_name}/" > "~{sample_name}.tar"
 		rm "~{sample_name}_varclfail.fastq"
 	fi
-
+	
+	echo "PASS" >> ERROR
 	echo "Variant calling completed."
 	>>>
 
@@ -199,6 +204,7 @@ task variant_call_one_sample_ref_included {
 		# debugging stuff
 		File? check_this_fastq = sample_name+"_varclfail.fastq.gz"
 		File? cortex_log = "var_call_"+sample_name+"/cortex/cortex.log"
+		String ERROR = read_string("ERROR")
 		File? ls1 = "contents_1.txt"
 		File? ls2 = "contents_2.txt"
 		File? ls3 = "contents_3.txt"


### PR DESCRIPTION
Adds task-level outputs that will return a status code for a given sample. This status code can be saved to a Terra data table, allowing someone to see at a glance why their sample failed (or if it passed).

Decontaminate task now can return:
* DECONTAMINATION_MAP_READS_TIMEOUT
* DECONTAMINATION_MAP_READS_KILLED
* DECONTAMINATION_MAP_READS_UNKNOWN_ERROR
* DECONTAMINATION_RM_CONTAM_TIMEOUT
* DECONTAMINATION_RM_CONTAM_KILLED
* DECONTAMINATION_RM_CONTAM_UNKNOWN_ERROR
* PASS

Variant caller now can return: 
* VARIANT_CALLING_TIMEOUT
* VARIANT_CALLING_KILLED
* VARIANT_CALLING_ADJUDICATION_FAILURE
* VARIANT_CALLING_UNKNOWN_ERROR
* PASS

The adjudication failure represents porting a check from an older version of the variant caller. That check will look at Cortex logs for a warning that, in my experience, indicates that a file was too small for Cortex but not small enough for minimap2. My understanding is that the actual error occurs in minos, so I'm calling this a minos error instead of a Cortex one.

This does not include any of the fancy calculus needed to get these error codes on a data table. That's the purview of myco_raw.