### PR TITLE
Task-level read drop counts

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -111,7 +111,7 @@ task combined_decontamination_single_ref_included {
 	do
 		size_inputfq=$(du -m "$inputfq" | cut -f1)
 		reads_inputfq=$(fqtools count "$inputfq")
-		printf "%s\t%s\t%s\n" "$inputfq" "$size_inputfq" "$reads_inputfq" >> input_fq_stats.tsv
+		printf "%s\t%s\t%s\n" "$inputfq" "$size_inputfq MB" "$reads_inputfq" >> fq_stats.tsv
 		#echo "$inputfq\t$size_inputfq\t$reads_inputfq" >> input_fq_stats.tsv
 		input_fq_size=$((input_fq_size+size_inputfq))
 		input_fq_reads=$((input_fq_reads+reads_inputfq))
@@ -309,7 +309,9 @@ task combined_decontamination_single_ref_included {
 	reads_difference=$((input_fq_reads - decon_reads_out))
 	echo "$size_difference" > size_difference
 	echo "$reads_difference" > reads_difference
-
+	printf "%s\t%s\t%s\n" "~{sample_name}_1.decontam.fq.gz" "$decon_size_out_1 MB" "$decon_reads_out_1" >> fq_stats.tsv
+	printf "%s\t%s\t%s\n" "~{sample_name}_2.decontam.fq.gz" "$decon_size_out_2 MB" "$decon_reads_out_2" >> fq_stats.tsv
+	
 	# We passed, so delete the output that would signal to run fastqc
 	rm "~{read_file_basename}_dcntmfail.fastq"
 	echo "PASS" >> ERROR
@@ -346,7 +348,7 @@ task combined_decontamination_single_ref_included {
 		Int seconds_total = read_int("timer_total")
 		Float size_difference = read_float("size_difference")
 		Float reads_difference = read_float("reads_difference")
-		File input_stats = "input_fq_stats.tsv"
+		File input_stats = "fq_stats.tsv"
 		String docker_used = docker_image
 	}
 	

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -104,7 +104,7 @@ task combined_decontamination_single_ref_included {
 	# input was. This works on Terra, but there is a chance this gets iffy elsewhere.
 	# If you're having issues with miniwdl, --copy-input-files might help
 	start_subsample=$SECONDS
-	touch input_fq_stats.tsv
+	echo "Please also check *.decontam.counts.tsv for more information.\n" >> fq_stats.tsv
 	input_fq_reads=0
 	input_fq_size=0
 	for inputfq in "${READS_FILES[@]}"
@@ -112,7 +112,6 @@ task combined_decontamination_single_ref_included {
 		size_inputfq=$(du -m "$inputfq" | cut -f1)
 		reads_inputfq=$(fqtools count "$inputfq")
 		printf "%s\t%s\t%s\n" "$inputfq" "$size_inputfq MB" "$reads_inputfq" >> fq_stats.tsv
-		#echo "$inputfq\t$size_inputfq\t$reads_inputfq" >> input_fq_stats.tsv
 		input_fq_size=$((input_fq_size+size_inputfq))
 		input_fq_reads=$((input_fq_reads+reads_inputfq))
 		# shellcheck disable=SC2004

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -111,7 +111,7 @@ task combined_decontamination_single_ref_included {
 	do
 		size_inputfq=$(du -m "$inputfq" | cut -f1)
 		reads_inputfq=$(fqtools count "$inputfq")
-		printf "%s\t%s\t%s" "$inputfq" "$size_inputfq" "$reads_inputfq" >> input_fq_stats.tsv
+		printf "%s\t%s\t%s\n" "$inputfq" "$size_inputfq" "$reads_inputfq" >> input_fq_stats.tsv
 		#echo "$inputfq\t$size_inputfq\t$reads_inputfq" >> input_fq_stats.tsv
 		input_fq_size=$((input_fq_size+size_inputfq))
 		input_fq_reads=$((input_fq_reads+reads_inputfq))
@@ -299,11 +299,11 @@ task combined_decontamination_single_ref_included {
 	echo ${timer_rm_contam} > timer_rm_contam
 	
 	# Calcuate size change
-	decon_size_out_1=$(du -m "~{sample_name}+_1.decontam.fq.gz" | cut -f1)
-	decon_size_out_2=$(du -m "~{sample_name}+_2.decontam.fq.gz" | cut -f1)
+	decon_size_out_1=$(du -m "~{sample_name}_1.decontam.fq.gz" | cut -f1)
+	decon_size_out_2=$(du -m "~{sample_name}_2.decontam.fq.gz" | cut -f1)
 	decon_size_out=$((decon_size_out_1 + decon_size_out_2))
-	decon_reads_out_1=$(fqtools count "~{sample_name}+_1.decontam.fq.gz")
-	decon_reads_out_2=$(fqtools count "~{sample_name}+_2.decontam.fq.gz")
+	decon_reads_out_1=$(fqtools count "~{sample_name}_1.decontam.fq.gz")
+	decon_reads_out_2=$(fqtools count "~{sample_name}_2.decontam.fq.gz")
 	decon_reads_out=$((decon_reads_out_1 + decon_reads_out_2))
 	size_difference=$((input_fq_size - decon_size_out))
 	reads_difference=$((input_fq_reads - decon_reads_out))
@@ -346,6 +346,7 @@ task combined_decontamination_single_ref_included {
 		Int seconds_total = read_int("timer_total")
 		Float size_difference = read_float("size_difference")
 		Float reads_difference = read_float("reads_difference")
+		File input_stats = "input_fq_stats.tsv"
 		String docker_used = docker_image
 	}
 	


### PR DESCRIPTION
This is mostly useful for diagnosing weirdness in multi-lane samples and if you need a quick number to represent how much stuff got dropped when decontaminating.

The reads data is about (but not exactly) half of what decontam.counts.tsv indicates... unsure why, but as long as this is taken as general information, I think that's okay.