### PR TITLE
Count reads, rm debug stuff from combined decontamination task

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -20,7 +20,6 @@ task combined_decontamination_single_ref_included {
 		Boolean     unsorted_sam = false
 
 		# rename outs
-		String? counts_out     # must end in counts.tsv
 		String? no_match_out_1
 		String? no_match_out_2
 		String? contam_out_1
@@ -160,9 +159,7 @@ task combined_decontamination_single_ref_included {
 	done
 
 	# map reads for decontamination
-	echo "****************"
 	echo "Mapping reads..."
-	echo "****************"
 	start_map_reads=$SECONDS
 	timeout -v ~{timeout_map_reads}m clockwork map_reads \
 		~{arg_unsorted_sam} \
@@ -214,17 +211,12 @@ task combined_decontamination_single_ref_included {
 	timer_map_reads=$(( SECONDS - start_map_reads ))
 	echo ${timer_map_reads} > timer_map_reads
 
-	# calculate the last three positional arguments of the rm_contam task
-	if [[ ! "~{counts_out}" = "" ]]
-	then
-		arg_counts_out="~{counts_out}"
-	else
-		arg_counts_out="~{sample_name}.decontam.counts.tsv"
-	fi
-
+	arg_counts_out="~{sample_name}.decontam.counts.tsv"
 	arg_reads_out1="~{sample_name}_1.decontam.fq.gz"
 	arg_reads_out2="~{sample_name}_2.decontam.fq.gz"
 
+	# handle samtools sort
+	#
 	# TODO: samtools sort doesn't seem to be in the nextflow version of this pipeline, but it seems
 	# we need it in the WDL version?
 	# https://github.com/iqbal-lab-org/clockwork/issues/77
@@ -233,7 +225,6 @@ task combined_decontamination_single_ref_included {
 	# This might intereact with unsorted_sam, which seems to actually be a dupe remover
 	# https://github.com/iqbal-lab-org/clockwork/blob/v0.11.3/python/clockwork/tasks/map_reads.py#L18
 	# https://github.com/iqbal-lab-org/clockwork/blob/v0.11.3/python/clockwork/read_map.py#L26
-	
 	start_samtools_sort=$SECONDS
 	echo "Sorting by read name..."
 	samtools sort -n ~{outfile_sam} > sorted_by_read_name_~{sample_name}.sam

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -140,11 +140,6 @@ task combined_decontamination_single_ref_included {
 	tar -xvf /ref/Ref.remove_contam.tar -C Ref.remove_contam --strip-components 1
 	timer_untar=$(( SECONDS - start_untar ))
 	echo ${timer_untar} > timer_untar
-	
-	# debug information, useful because different WDL executors handle stuff differently
-	echo "Debug information: workdir is $(pwd)"
-	echo "Contents of ./Ref.remove_contam/:"
-	tree Ref.remove_contam/
 
 	# anticipate bad fastqs
 	#

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -28,8 +28,9 @@ task combined_decontamination_single_ref_included {
 
 		# runtime attributes
 		Int addldisk = 100
-		String docker_image = "ashedpotatoes/clockwork-plus:v0.11.3.2-full"
 		Int cpu = 8
+		String docker_image = "ashedpotatoes/clockwork-plus:v0.11.3.2-full"
+		Int max_retries = 0
 		Int memory = 16
 		Int preempt = 1
 		Boolean ssd = true
@@ -304,6 +305,7 @@ task combined_decontamination_single_ref_included {
 		cpu: cpu
 		docker: docker_image
 		disks: "local-disk " + finalDiskSize + diskType
+		maxRetries: max_retries
 		memory: "${memory} GB"
 		preemptible: "${preempt}"
 	}

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -287,9 +287,15 @@ task combined_decontamination_single_ref_included {
 	timer_rm_contam=$(( SECONDS - start_rm_contam ))
 	echo ${timer_rm_contam} > timer_rm_contam
 
-	# We passed, so delete the output that would signal to run fastqc
+	# if we got here, then we passed, so delete the output that would signal to run fastqc
 	rm "~{read_file_basename}_dcntmfail.fastq"
 	echo "PASS" >> ERROR
+	
+	# parse decontam.counts.tsv
+	cat $arg_counts_out | head -2 | tail -1 | cut -f3 > reads_is_contam
+	cat $arg_counts_out | head -3 | tail -1 | cut -f3 > reads_reference
+	cat $arg_counts_out | head -4 | tail -1 | cut -f3 > reads_unmapped
+	cat $arg_counts_out | head -5 | tail -1 | cut -f3 > reads_kept
 	
 	timer_total=$(( SECONDS - start_total ))
 	echo ${timer_total} > timer_total
@@ -308,7 +314,6 @@ task combined_decontamination_single_ref_included {
 	}
 
 	output {
-		#File? mapped_to_decontam = glob("*.sam")[0]
 		File? counts_out_tsv = sample_name + ".decontam.counts.tsv"
 		File? decontaminated_fastq_1 = sample_name + "_1.decontam.fq.gz"
 		File? decontaminated_fastq_2 = sample_name + "_2.decontam.fq.gz"
@@ -316,12 +321,19 @@ task combined_decontamination_single_ref_included {
 		String errorcode = read_string("ERROR")
 		
 		# timers and debug information
-		#Int seconds_to_untar = read_int("timer_untar")
-		Int seconds_to_map_reads = read_int("timer_map_reads")
-		Int seconds_to_sort = read_int("timer_samtools_sort")
-		Int seconds_to_rm_contam = read_int("timer_rm_contam")
-		Int seconds_total = read_int("timer_total")
+		Int timer_map_reads = read_int("timer_map_reads")
+		Int timer_rm_contam = read_int("timer_rm_contam")
+		Int timer_total = read_int("timer_total")
 		String docker_used = docker_image
+		Int reads_is_contam = read_int("reads_is_contam")
+		Int reads_reference = read_int("reads_reference")
+		Int reads_unmapped = read_int("reads_unmapped")
+		Int reads_kept = read_int("reads_kept")
+		
+		# you probably don't want these...
+		#File? mapped_to_decontam = glob("*.sam")[0]
+		#Int timer_sort = read_int("timer_samtools_sort")
+		#Int seconds_to_untar = read_int("timer_untar")
 	}
 	
 }

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -265,10 +265,10 @@ task variant_call_one_sample_ref_included {
 		File? check_this_fastq = sample_name+"_varclfail.fastq.gz"
 		File? cortex_log = "var_call_"+sample_name+"/cortex/cortex.log"
 		String errorcode = read_string("ERROR")
-		File? ls1 = "contents_1.txt"
-		File? ls2 = "contents_2.txt"
-		File? ls3 = "contents_3.txt"
-		File? workdir_tarball = sample_name+".tar"
+		#File? ls1 = "contents_1.txt"
+		#File? ls2 = "contents_2.txt"
+		#File? ls3 = "contents_3.txt"
+		File? workdir_tarball = sample_name+".tar"  # only if debug is true and something breaks
 	}
 }
 


### PR DESCRIPTION
## Changes
* User can no longer define the counts out TSV file name
* User can set max_retries (default: 0) to take advantage of Terra's retry with more memory feature
* All reads are sized, even if not subsampling, to throw a warning if there's less than a thousand
* Remove some outdated debugging prints
* Parses the counts file to count the number of reads that were determined to be contamination, unmapped, reference, and remaining.
* Clarify the timers are in seconds, and remove the ones no one cares about