### PR TITLE
Fix .fastq file extension and a VCF failsafe

### DIFF
--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -172,6 +172,7 @@ task clean_and_decontam_and_check {
 	else
 		echo "Failed to located decontamination reference"
 		exit 1
+	fi
 	if [ -f "~{arg_ref_fasta}" ]
 	then
 		echo "Located decontamination reference at ~{arg_ref_fasta}"

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -92,8 +92,10 @@ task clean_and_decontam_and_check {
 	# So, we instead need to know output filenames before the command block
 	# executes.
 	String fastq_suffix_regex = "\\.f(ast)?q(\\.gz)?$"
+	String pair_suffix_regex = "_[12]$"
 	String read_file_basename = basename(reads_files[0]) # used to calculate sample name + outfile_sam
-	String clean_basename = sub(sub(read_file_basename, fastq_suffix_regex, ""), "\\.tar$", "")
+	String ext_stripped = sub(sub(read_file_basename, fastq_suffix_regex, ""), "\\.tar$", "")
+	String clean_basename = sub(ext_stripped, pair_suffix_regex, "")
 	String sample_name_if_strip_all_underscores = sub(clean_basename, "_.*", "")
 	String sample_name = if strip_all_underscores then sample_name_if_strip_all_underscores else clean_basename
 	String outfile_sam = sample_name + ".sam"
@@ -105,10 +107,8 @@ task clean_and_decontam_and_check {
 	String arg_reads_out2 = out_prefix + "_2.decontam.fq.gz"
 	String reads_cleaned_1 = out_prefix + "_1.clean.fq.gz"
 	String reads_cleaned_2 = out_prefix + "_2.clean.fq.gz"
-	String usual_final_fastq1 = arg_reads_out1
-	String usual_final_fastq2 = arg_reads_out2
-	String final_fastq1 = out_prefix + "_1.fq.gz"
-	String final_fastq2 = out_prefix + "_2.fq.gz"
+	String final_fastq1 = arg_reads_out1
+	String final_fastq2 = arg_reads_out2
 
 	# This region handles optional arguments
 	String arg_contam_out_1 = if(!defined(contam_out_1)) then "" else "--contam_out_1 ~{contam_out_1}"
@@ -304,8 +304,6 @@ task clean_and_decontam_and_check {
 	echo "arg_reads_out2: ~{arg_reads_out2}"
 	echo "reads_cleaned_1: ~{reads_cleaned_1}"
 	echo "reads_cleaned_2: ~{reads_cleaned_2}"
-	echo "usual_final_fastq1: ~{usual_final_fastq1}"
-	echo "usual_final_fastq2: ~{usual_final_fastq2}"
 	echo "final_fastq1: ~{final_fastq1}"
 	echo "final_fastq2: ~{final_fastq2}"
 
@@ -403,8 +401,8 @@ task clean_and_decontam_and_check {
 			echo "Due to QC failure, no .fq output will be given. Crashing!"
 			exit 1
 		else
-			rm "~{usual_final_fastq1}" 
-			rm "~{usual_final_fastq2}"
+			rm "~{final_fastq1}" 
+			rm "~{final_fastq2}"
 			echo "Due to QC failure, no .fq output will be given."
 			exit 0
 		fi
@@ -713,12 +711,12 @@ task clean_and_decontam_and_check {
 
 	CODE
 
-	if [[ $(fqtools count "~{usual_final_fastq1}") -le ~{minimum_number_of_passing_reads} ]]
+	if [[ $(fqtools count "~{final_fastq1}") -le ~{minimum_number_of_passing_reads} ]]
 	then
 		echo "This sample has less than ~{minimum_number_of_passing_reads} reads and risks breaking the variant caller. We're getting rid of it."
 		echo "LESS_THAN_~{minimum_number_of_passing_reads}_READS_LATE" > ERROR.TXT
-		rm "~{usual_final_fastq1}" 
-		rm "~{usual_final_fastq2}"
+		rm "~{final_fastq1}" 
+		rm "~{final_fastq2}"
 		# exit handled in grep block below
 	fi
 
@@ -733,18 +731,11 @@ task clean_and_decontam_and_check {
 			echo "Due to QC failure, no .fq output will be given. Crashing!"
 			exit 1
 		else
-			rm "~{usual_final_fastq1}" 
-			rm "~{usual_final_fastq2}"
+			rm "~{final_fastq1}" 
+			rm "~{final_fastq2}"
 			echo "Due to QC failure, no .fq output will be given."
 			exit 0
 		fi
-	fi
-	
-	# rename outputs if necessary
-	if [[ ! "~{force_rename_out}" = "" ]]
-	then
-		mv "~{usual_final_fastq1}" "~{final_fastq1}"
-		mv "~{usual_final_fastq2}" "~{final_fastq2}"
 	fi
 
 	tree

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -75,8 +75,8 @@ task clean_and_decontam_and_check {
 	String docker_version = if oldschool_docker then "ashedpotatoes/clockwork-plus:v0.11.3.11" else "ashedpotatoes/clockwork-plus:v0.12.5.3"
 	String docker_decontam = if CDC_decontamination_reference then "-CDC" else "-CRyPTIC"
 	String docker_image = docker_version + docker_decontam
-	String arg_metadata_tsv = "/ref/Ref.remove_contam/remove_contam_metadata.tsv"
-	String arg_ref_fasta = "/ref/Ref.remove_contam/ref.fa"
+	String arg_metadata_tsv = if oldschool_docker then "/Ref.remove_contam/remove_contam_metadata.tsv" else "/ref/Ref.remove_contam/remove_contam_metadata.tsv"
+	String arg_ref_fasta = if oldschool_docker then "/Ref.remove_contam/ref.fa" else "/ref/Ref.remove_contam/ref.fa"
 
 	# We need to derive the sample name from our inputs because sample name is a
 	# required input for clockwork map_reads. This needs to be to handle inputs

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -221,6 +221,16 @@ task clean_and_decontam_and_check {
 	READS_FILES_RAW=("~{sep='" "' reads_files}")
 	fx_echo_array "Inputs as passed in:" "${READS_FILES_RAW[@]}"
 	for fq in "${READS_FILES_RAW[@]}"; do mv "$fq" .; done 
+
+	# decapitalize because clockwork can't tell .FQ.GZ is gzipped and errors out
+	for file in *; do
+		case "$file" in
+			*.FASTQ)    echo "Renaming $file to ${file%.FASTQ}.fastq" ;;
+			*.FQ.GZ)    echo "Renaming $file to ${file%.FQ.GZ}.fq.gz" ;;
+			*.FASTQ.GZ) echo "Renaming $file to ${file%.FASTQ.GZ}.fastq.gz" ;;
+		esac
+	done
+
 	# I really did try to make these next three lines just one -iregex string but
 	# kept messing up the syntax -- this approach is unsatisfying but cleaner
 	readarray -d '' -t BAD_FQ < <(find . -iname "*.fq*" -print0)

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -91,23 +91,24 @@ task clean_and_decontam_and_check {
 	# having nothing at index 0 is okay if that output is an optional file.
 	# So, we instead need to know output filenames before the command block
 	# executes.
+	String fastq_suffix_regex = "\\.f(ast)?q(\\.gz)?$"
 	String read_file_basename = basename(reads_files[0]) # used to calculate sample name + outfile_sam
-	String sample_name_if_strip_all_underscores = sub(sub(sub(read_file_basename, "_.*", ""), ".gz", ""), ".tar", "")
-	String sample_name_if_more_polite_strip     = sub(sub(read_file_basename, ".gz", ""), ".tar", "")
-	String sample_name = if strip_all_underscores then sample_name_if_strip_all_underscores else sample_name_if_more_polite_strip
+	String clean_basename = sub(sub(read_file_basename, fastq_suffix_regex, ""), "\\.tar$", "")
+	String sample_name_if_strip_all_underscores = sub(clean_basename, "_.*", "")
+	String sample_name = if strip_all_underscores then sample_name_if_strip_all_underscores else clean_basename
 	String outfile_sam = sample_name + ".sam"
 	
-	# Hardcoded to make delocalization less of a pain, at the cost of being ugly
-	# Note: For reads_cleaned I tried sub() with "\\.f(ast)?q\\.gz$" but that doesn't seem to work for .fastq.gz so I'm reverting to a more simple form
-	String arg_counts_out = if(defined(force_rename_out)) then select_first([force_rename_out, sample_name]) + ".decontam.counts.tsv" else sample_name + ".decontam.counts.tsv"
-	String arg_reads_out1 = if(defined(force_rename_out)) then select_first([force_rename_out, sample_name]) + "_1.decontam.fq.gz" else sample_name + "_1.decontam.fq.gz" 
-	String arg_reads_out2 = if(defined(force_rename_out)) then select_first([force_rename_out, sample_name]) + "_2.decontam.fq.gz" else sample_name + "_2.decontam.fq.gz"
-	String reads_cleaned_1 = if(defined(force_rename_out)) then select_first([force_rename_out, sample_name]) + "_1.clean.fq.gz" else sub(sample_name, ".fq.gz", "_1.clean.fq.gz")
-	String reads_cleaned_2 = if(defined(force_rename_out)) then select_first([force_rename_out, sample_name]) + "_2.clean.fq.gz" else sub(sample_name, ".fq.gz", "_2.clean.fq.gz")
+	# For the outputs -- hardcoded to make delocalization less terrible
+	String out_prefix = select_first([force_rename_out, sample_name])
+	String arg_counts_out = out_prefix + ".decontam.counts.tsv"
+	String arg_reads_out1 = out_prefix + "_1.decontam.fq.gz" 
+	String arg_reads_out2 = out_prefix + "_2.decontam.fq.gz"
+	String reads_cleaned_1 = out_prefix + "_1.clean.fq.gz"
+	String reads_cleaned_2 = out_prefix + "_2.clean.fq.gz"
 	String usual_final_fastq1 = arg_reads_out1
 	String usual_final_fastq2 = arg_reads_out2
-	String final_fastq1 = if(defined(force_rename_out)) then select_first([force_rename_out, sample_name]) + "_1.fq.gz" else usual_final_fastq1
-	String final_fastq2 = if(defined(force_rename_out)) then select_first([force_rename_out, sample_name]) + "_2.fq.gz" else usual_final_fastq2
+	String final_fastq1 = out_prefix + "_1.fq.gz"
+	String final_fastq2 = out_prefix + "_2.fq.gz"
 
 	# This region handles optional arguments
 	String arg_contam_out_1 = if(!defined(contam_out_1)) then "" else "--contam_out_1 ~{contam_out_1}"
@@ -294,8 +295,8 @@ task clean_and_decontam_and_check {
 
 	# this is cringe, but helps debug certain annoying edge cases
 	echo "read_file_basename: ~{read_file_basename}"
+	echo "clean_basename: ~{clean_basename}"
 	echo "sample_name_if_strip_all_underscores: ~{sample_name_if_strip_all_underscores}"
-	echo "sample_name_if_more_polite_strip: ~{sample_name_if_more_polite_strip}"
 	echo "sample_name: ~{sample_name}"
 	echo "force_rename_out: ~{force_rename_out}"
 	echo "arg_counts_out: ~{arg_counts_out}"

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -75,8 +75,8 @@ task clean_and_decontam_and_check {
 	String docker_version = if oldschool_docker then "ashedpotatoes/clockwork-plus:v0.11.3.11" else "ashedpotatoes/clockwork-plus:v0.12.5.3"
 	String docker_decontam = if CDC_decontamination_reference then "-CDC" else "-CRyPTIC"
 	String docker_image = docker_version + docker_decontam
-	String arg_metadata_tsv = if oldschool_docker then "/Ref.remove_contam/remove_contam_metadata.tsv" else "/ref/Ref.remove_contam/remove_contam_metadata.tsv"
-	String arg_ref_fasta = if oldschool_docker then "/Ref.remove_contam/ref.fa" else "/ref/Ref.remove_contam/ref.fa"
+	String arg_metadata_tsv = if oldschool_docker then "./Ref.remove_contam/remove_contam_metadata.tsv" else "/ref/Ref.remove_contam/remove_contam_metadata.tsv"
+	String arg_ref_fasta = if oldschool_docker then "./Ref.remove_contam/ref.fa" else "/ref/Ref.remove_contam/ref.fa"
 
 	# We need to derive the sample name from our inputs because sample name is a
 	# required input for clockwork map_reads. This needs to be to handle inputs
@@ -172,7 +172,14 @@ task clean_and_decontam_and_check {
 	else
 		echo "Failed to located decontamination reference"
 		exit 1
+	if [ -f "~{arg_ref_fasta}" ]
+	then
+		echo "Located decontamination reference at ~{arg_ref_fasta}"
+	else
+		echo "Could not find decontamination reference at ~{arg_ref_fasta} even after trying to untar!"
+		exit 1
 	fi
+
 	echo "workdir contents:"
 	tree
 

--- a/tasks/combined_decontamination.wdl
+++ b/tasks/combined_decontamination.wdl
@@ -823,9 +823,9 @@ task clean_and_decontam_and_check {
 		Int timer_c_dcnFQ = read_int("timer_7_rm_contam")
 		Int timer_total   = read_int("timer_total")
 		String docker_used = docker_image
-		File? counts_out_tsv = sample_name + ".decontam.counts.tsv"      # should match $arg_counts_out
-		File? fastp_report_1 = sample_name + "_first_fastp.json"
-		File? fastp_report_2 = sample_name + "_second_fastp.json"
+		File? counts_out_tsv = arg_counts_out
+		File? fastp_report_1 = out_prefix + "_first_fastp.json"
+		File? fastp_report_2 = out_prefix + "_second_fastp.json"
 		
 		# you probably don't want these...
 		#File? mapped_to_decontam = glob("*.sam")[0]

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -193,9 +193,9 @@ task variant_call_one_sample_ref_included {
 		echo "Samtools:"
 		cat "var_call_~{sample_name}/samtools.vcf"
 		echo "Cortex:"
-		cat "var_call_"~{sample_name}/cortex.vcf"
+		cat "var_call_~{sample_name}/cortex.vcf"
 		echo "Adjudicated:"
-		cat "var_call_"~{sample_name}/final.vcf"
+		cat "var_call_~{sample_name}/final.vcf"
 
 		# delete the VCF so it doesn't get delocalized
 		rm "var_call_~{sample_name}/final.vcf"
@@ -208,16 +208,16 @@ task variant_call_one_sample_ref_included {
 			exit 0
 		fi
 	else
-		echo "VCF file is $(wc -l var_call_'~{sample_name}'/final.vcf) lines long. It's probably fine."
+		echo "VCF file is $lines lines long. It's probably fine."
 	fi
 
 	echo mving VCFs from "var_call_~{sample_name}/*.vcf" to "./~{sample_name}*.vcf"
 
-	mv var_call_"~{sample_name}"/final.vcf ./"~{sample_name}".vcf
+	mv "var_call_~{sample_name}/final.vcf" "./~{sample_name}.vcf"
 
 	# rename the bam and bai files
 	mv "var_call_~{sample_name}/map.bam" "./~{sample_name}_to_H37Rv.bam"
-	mv "var_call_~{sample_name}/map.bam.bai" "./~{sample_name}"_to_H37Rv.bam.bai"
+	mv "var_call_~{sample_name}/map.bam.bai" "./~{sample_name}_to_H37Rv.bam.bai"
 	
 	if [[ "~{tarball_bams_and_bais}" = "true" ]]
 	then

--- a/tasks/variant_call_one_sample.wdl
+++ b/tasks/variant_call_one_sample.wdl
@@ -185,19 +185,20 @@ task variant_call_one_sample_ref_included {
 	fi
 
 	# check that the final VCF file is more than four lines in length
-	if [ "$(wc -l < file.txt)" -lt 4 ]
+	lines=$(wc -l < "var_call_~{sample_name}/final.vcf")
+	if [ "$lines" -lt 4 ]
 	then
 		echo "Adjudicated VCF file is less than four lines long. This almost certainly means that no variants were found!"
 		echo "Dump of all VCF files to stdout:"
 		echo "Samtools:"
-		cat var_call_"~{sample_name}"/samtools.vcf
+		cat "var_call_~{sample_name}/samtools.vcf"
 		echo "Cortex:"
-		cat var_call_"~{sample_name}"/cortex.vcf
+		cat "var_call_"~{sample_name}/cortex.vcf"
 		echo "Adjudicated:"
-		cat var_call_"~{sample_name}"/final.vcf
+		cat "var_call_"~{sample_name}/final.vcf"
 
 		# delete the VCF so it doesn't get delocalized
-		rm var_call_"~{sample_name}"/final.vcf
+		rm "var_call_~{sample_name}/final.vcf"
 		echo "VARIANT_CALLING_EMPTY_FILE" >> ERROR
 		if [[ "~{crash_on_error}" = "true" ]]
 		then
@@ -210,26 +211,26 @@ task variant_call_one_sample_ref_included {
 		echo "VCF file is $(wc -l var_call_'~{sample_name}'/final.vcf) lines long. It's probably fine."
 	fi
 
-	echo mving VCFs from var_call_"~{sample_name}"/*.vcf to ./"~{sample_name}"*.vcf
+	echo mving VCFs from "var_call_~{sample_name}/*.vcf" to "./~{sample_name}*.vcf"
 
 	mv var_call_"~{sample_name}"/final.vcf ./"~{sample_name}".vcf
 
 	# rename the bam and bai files
-	mv var_call_"~{sample_name}"/map.bam ./"~{sample_name}"_to_H37Rv.bam
-	mv var_call_"~{sample_name}"/map.bam.bai ./"~{sample_name}"_to_H37Rv.bam.bai
+	mv "var_call_~{sample_name}/map.bam" "./~{sample_name}_to_H37Rv.bam"
+	mv "var_call_~{sample_name}/map.bam.bai" "./~{sample_name}"_to_H37Rv.bam.bai"
 	
 	if [[ "~{tarball_bams_and_bais}" = "true" ]]
 	then
 		mkdir "~{sample_name}_aligned_to_H37Rv"
-		mv ./"~{sample_name}"_to_H37Rv.bam ./"~{sample_name}_aligned_to_H37Rv"/"~{sample_name}".bam
-		mv ./"~{sample_name}"_to_H37Rv.bam.bai ./"~{sample_name}_aligned_to_H37Rv"/"~{sample_name}".bam.bai
+		mv "./~{sample_name}_to_H37Rv.bam" ./"~{sample_name}_aligned_to_H37Rv/~{sample_name}.bam"
+		mv "./~{sample_name}_to_H37Rv.bam.bai" ./"~{sample_name}_aligned_to_H37Rv/~{sample_name}.bam.bai"
 		tar -c "~{sample_name}_aligned_to_H37Rv/" > "~{sample_name}_aligned_to_H37Rv.tar"
 	fi
 
 	if [[ "~{debug}" = "true" ]]
 	then
-		mv var_call_"~{sample_name}"/cortex.vcf ./"~{sample_name}"_cortex.vcf
-		mv var_call_"~{sample_name}"/samtools.vcf ./"~{sample_name}"_samtools.vcf
+		mv "var_call_~{sample_name}/cortex.vcf" "./~{sample_name}_cortex.vcf"
+		mv "var_call_~{sample_name}/samtools.vcf" "./~{sample_name}_samtools.vcf"
 	fi
 	
 	echo "PASS" >> ERROR


### PR DESCRIPTION
Fixes:
* Fix legacy Docker image (v0.11.3) getting the wrong path to its reference genomes
* "VCF is more than four lines" failsafe was being applied to a non-existent hardcoded filename
* Bring back support for .fastq file extension

Logic changes:
* Revert from using WDL built-in sub() back to regex, for handling output file names, but the regex is actually correct this time
* Add assert for locating the decontamination reference
* Redo dquoting in variant caller task (I genuinely do not know why I did it the other way earlier, yeesh)

TO TEST:
* .fastq.gz, .fq.gz, .fq, .FASTQ, .FASTQ.GZ, .FQ.GZ, .FQ
* Cromwell and Terra
* strip_all_underscores --> might deprecate this; this was a workaround for bad sample CDPH sample names but we now have a better workaround